### PR TITLE
a11y: enforce WCAG AA color contrast + fix link names (POR-1)

### DIFF
--- a/app/HomeContent.tsx
+++ b/app/HomeContent.tsx
@@ -50,12 +50,12 @@ export default function HomeContent({ featuredPosts }: Props) {
               lives here. Wrapping in framer-motion delays paint by ~2.6s
               while the bundle hydrates and the opacity:0 → 1 transition
               runs. CSS-only fade keeps Lighthouse perf above 90. */}
-          <div className="motion-safe:animate-[fade-in-up_0.5s_ease-out] space-y-6 lg:w-1/2">
+          <div className="space-y-6 motion-safe:animate-[fade-in-up_0.5s_ease-out] lg:w-1/2">
             <div className="space-y-2">
               <Badge variant="outline" className="text-sm font-medium">
                 Available for hire · Open to part-time & freelance
               </Badge>
-              <h1 className="text-foreground text-4xl font-bold lg:text-6xl">
+              <h1 className="text-4xl font-bold text-foreground lg:text-6xl">
                 Hi, I&apos;m Shailesh Chaudhari
               </h1>
               <h2 className="bg-gradient-to-r from-primary to-purple-600 bg-clip-text text-2xl font-semibold leading-tight text-transparent sm:text-3xl lg:text-3xl">
@@ -63,16 +63,16 @@ export default function HomeContent({ featuredPosts }: Props) {
               </h2>
             </div>
 
-            <p className="text-muted-foreground text-lg leading-relaxed">
-              ~2.5 years in the industry. Currently at ContextQA working on
-              the backend of our core QA-automation product — test execution
-              engine, VNC streaming, and multi-cloud browser orchestration
-              across Playwright / WebdriverIO / LambdaTest. Comfortable across
-              the stack from my EsparkBiz client-project days, but I go deep
-              on backend systems: distributed locks (Redlock), real-time
-              pub/sub (Socket.io + Redis adapter), webhook idempotency (SETNX),
-              AI pipelines (Gemini function-calling). Targeting backend,
-              platform, or developer-tooling roles.
+            <p className="text-lg leading-relaxed text-muted-foreground">
+              ~2.5 years in the industry. Currently at ContextQA working on the
+              backend of our core QA-automation product — test execution engine,
+              VNC streaming, and multi-cloud browser orchestration across
+              Playwright / WebdriverIO / LambdaTest. Comfortable across the
+              stack from my EsparkBiz client-project days, but I go deep on
+              backend systems: distributed locks (Redlock), real-time pub/sub
+              (Socket.io + Redis adapter), webhook idempotency (SETNX), AI
+              pipelines (Gemini function-calling). Targeting backend, platform,
+              or developer-tooling roles.
             </p>
 
             <div className="flex flex-wrap gap-2">
@@ -158,7 +158,7 @@ export default function HomeContent({ featuredPosts }: Props) {
             </div>
           </div>
 
-          <div className="motion-safe:animate-[fade-in-scale_0.5s_ease-out] flex justify-center lg:w-1/2 lg:justify-end">
+          <div className="flex justify-center motion-safe:animate-[fade-in-scale_0.5s_ease-out] lg:w-1/2 lg:justify-end">
             <div className="relative h-72 w-72 overflow-hidden rounded-full lg:h-[500px] lg:w-[500px]">
               <div className="absolute inset-0 rounded-full bg-gradient-to-r from-primary/20 to-purple-600/20 blur-3xl" />
               <Image
@@ -184,10 +184,10 @@ export default function HomeContent({ featuredPosts }: Props) {
           transition={{ duration: 0.5 }}
           className="mb-10 text-center"
         >
-          <p className="mb-2 text-xs font-bold uppercase tracking-[0.3em] text-primary/70">
+          <p className="mb-2 text-xs font-bold uppercase tracking-[0.3em] text-primary">
             Side projects
           </p>
-          <h2 className="text-foreground text-3xl font-bold lg:text-4xl">
+          <h2 className="text-3xl font-bold text-foreground lg:text-4xl">
             Things I&apos;m building to learn
           </h2>
           <p className="mx-auto mt-3 max-w-2xl text-muted-foreground">
@@ -240,7 +240,7 @@ export default function HomeContent({ featuredPosts }: Props) {
                     {card.tag}
                   </span>
                 </div>
-                <h3 className="text-foreground mb-3 text-xl font-bold transition-colors group-hover:text-primary">
+                <h3 className="mb-3 text-xl font-bold text-foreground transition-colors group-hover:text-primary">
                   {card.title}
                 </h3>
                 <p className="mb-6 text-sm leading-relaxed text-muted-foreground">
@@ -269,10 +269,10 @@ export default function HomeContent({ featuredPosts }: Props) {
           transition={{ duration: 0.6, delay: 0.2 }}
           className="mb-12 text-center"
         >
-          <h2 className="text-foreground mb-4 text-3xl font-bold lg:text-4xl">
+          <h2 className="mb-4 text-3xl font-bold text-foreground lg:text-4xl">
             Featured Articles
           </h2>
-          <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+          <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
             Dive into my latest insights on software development,
             problem-solving, and career growth.
           </p>
@@ -297,10 +297,10 @@ export default function HomeContent({ featuredPosts }: Props) {
                       {post.readTime}
                     </span>
                   </div>
-                  <h3 className="text-foreground mb-3 line-clamp-2 text-xl font-semibold transition-colors group-hover:text-primary">
+                  <h3 className="mb-3 line-clamp-2 text-xl font-semibold text-foreground transition-colors group-hover:text-primary">
                     {post.title}
                   </h3>
-                  <p className="text-muted-foreground mb-4 line-clamp-3 text-sm">
+                  <p className="mb-4 line-clamp-3 text-sm text-muted-foreground">
                     {post.description}
                   </p>
                   <div className="flex flex-wrap gap-1">

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -87,7 +87,10 @@ export default async function Page({ params }: Props) {
   // Strip HTML for word-count — Google uses wordCount + timeRequired as
   // ranking signals for in-depth articles, and AI summarizers use them to
   // decide how much of the post to quote.
-  const plain = post.content.replaceAll(/<[^>]+>/g, " ").replaceAll(/\s+/g, " ").trim();
+  const plain = post.content
+    .replaceAll(/<[^>]+>/g, " ")
+    .replaceAll(/\s+/g, " ")
+    .trim();
   const wordCount = plain ? plain.split(" ").length : 0;
   // ISO 8601 duration — readTime in frontmatter is "16 min read"; extract digits.
   const readMin = Number.parseInt(post.readTime?.match(/\d+/)?.[0] || "5", 10);
@@ -159,7 +162,7 @@ export default async function Page({ params }: Props) {
 
         <BlogLayout post={post}>
           <div
-            className="prose prose-invert prose-lg max-w-none"
+            className="prose prose-lg max-w-none dark:prose-invert"
             dangerouslySetInnerHTML={{ __html: post.content }}
           />
         </BlogLayout>

--- a/app/contact/ContactContent.tsx
+++ b/app/contact/ContactContent.tsx
@@ -57,7 +57,7 @@ const InputField: React.FC<InputFieldProps> = ({
     <div className="mb-4">
       <label
         htmlFor={name}
-        className="text-foreground mb-2 block text-sm font-medium"
+        className="mb-2 block text-sm font-medium text-foreground"
       >
         {label}
       </label>
@@ -67,7 +67,7 @@ const InputField: React.FC<InputFieldProps> = ({
         aria-invalid={error ? "true" : undefined}
         aria-describedby={error ? errorId : undefined}
         {...register(name, rules)}
-        className={`bg-background text-foreground w-full rounded-md border px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary ${
+        className={`w-full rounded-md border bg-background px-4 py-2 text-foreground focus:outline-none focus:ring-2 focus:ring-primary ${
           error ? "border-red-500" : "border-gray-700"
         }`}
       />
@@ -366,7 +366,7 @@ export const ContactContent: React.FC = () => {
                 type="submit"
                 size="lg"
                 disabled={isSubmitting}
-                className="w-full bg-primary text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                className="w-full bg-primary-solid text-white hover:bg-primary-solid/90 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isSubmitting ? "Processing..." : "Send Message"}
               </Button>
@@ -384,8 +384,8 @@ export const ContactContent: React.FC = () => {
                 <span className="text-lg">✅</span>{" "}
                 <span className="font-semibold">Message sent.</span> I&apos;ll
                 reply from{" "}
-                <span className="font-medium">{CONTACT_INFO.EMAIL}</span>{" "}
-                within a day or two.
+                <span className="font-medium">{CONTACT_INFO.EMAIL}</span> within
+                a day or two.
               </div>
             )}
             {submitStatus === "success-fallback" && (
@@ -429,7 +429,10 @@ export const ContactContent: React.FC = () => {
               <a
                 href={`mailto:${CONTACT_INFO.EMAIL}`}
                 className="font-medium text-primary hover:underline"
-              >{CONTACT_INFO.EMAIL}</a>.
+              >
+                {CONTACT_INFO.EMAIL}
+              </a>
+              .
             </p>
           </form>
         </motion.div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,6 +19,15 @@
     --primary: 265 89% 55%;
     --primary-foreground: 0 0% 100%;
 
+    /* Solid purple surface token (buttons / badges / pills that carry text
+       ON TOP of the fill). Kept dark enough that white text clears WCAG AA
+       4.5:1 in BOTH themes — `--primary` itself is tuned for use AS text on
+       the page background, which pulls the opposite direction, so the two
+       roles are deliberately decoupled. Light value matches the old primary
+       so button/badge shades are visually unchanged in light mode. */
+    --primary-solid: 265 89% 55%;
+    --primary-solid-foreground: 0 0% 100%;
+
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 222 47% 11%;
 
@@ -62,8 +71,18 @@
     --popover: 222 47% 11%;
     --popover-foreground: 0 0% 98%;
 
-    --primary: 265 89% 65%;
+    /* Bumped 65% -> 72% so `text-primary` clears AA 4.5:1 on the dark canvas
+       (was 4.36:1) AND on the faint `bg-primary/10` chip tint used app-wide
+       (purple-on-purple composites lower, ~4.3:1 at 68%). White text never
+       sits on raw `--primary` in dark mode — those surfaces use
+       `--primary-solid` below. */
+    --primary: 265 89% 72%;
     --primary-foreground: 0 0% 98%;
+
+    /* Darker than `--primary` so white text on the fill clears AA (7:1) in
+       dark mode. See the light-mode note above. */
+    --primary-solid: 265 89% 50%;
+    --primary-solid-foreground: 0 0% 100%;
 
     --secondary: 217 32.6% 17.5%;
     --secondary-foreground: 0 0% 98%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -109,7 +109,10 @@ export default function RootLayout({
         {/* IndieWeb / rel=me — proves the social profiles belong to the same
             person, used by Mastodon for verification ticks and by IndieAuth. */}
         <link rel="me" href="https://github.com/Shailesh93602" />
-        <link rel="me" href="https://www.linkedin.com/in/shaileshbhaichaudhari" />
+        <link
+          rel="me"
+          href="https://www.linkedin.com/in/shaileshbhaichaudhari"
+        />
         <link rel="me" href="https://twitter.com/ShaileshWork" />
         <link rel="me" href="mailto:shailesh93602@gmail.com" />
         {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
@@ -310,7 +313,7 @@ export default function RootLayout({
           >
             <a
               href="#main-content"
-              className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[200] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg"
+              className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[200] focus:rounded-md focus:bg-primary-solid focus:px-4 focus:py-2 focus:text-primary-solid-foreground focus:shadow-lg"
             >
               Skip to main content
             </a>

--- a/app/portfolio/PortfolioContent.tsx
+++ b/app/portfolio/PortfolioContent.tsx
@@ -113,14 +113,14 @@ export function PortfolioContent() {
                  not 6+ wrapped rows pushing every card below the fold.
                  sm and up: wrap as before. */}
             <div className="mx-auto max-w-4xl">
-              <div className="-mx-4 flex gap-2 overflow-x-auto scroll-smooth px-4 pb-2 sm:mx-0 sm:flex-wrap sm:justify-center sm:gap-3 sm:overflow-visible sm:px-0 sm:pb-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+              <div className="-mx-4 flex gap-2 overflow-x-auto scroll-smooth px-4 pb-2 [scrollbar-width:none] sm:mx-0 sm:flex-wrap sm:justify-center sm:gap-3 sm:overflow-visible sm:px-0 sm:pb-0 [&::-webkit-scrollbar]:hidden">
                 {allTags.map((tag) => (
                   <button
                     key={tag}
                     onClick={() => toggleTag(tag)}
                     className={`shrink-0 whitespace-nowrap rounded-xl border px-3 py-2 text-xs font-bold uppercase tracking-wider transition-all duration-300 sm:px-5 sm:py-2.5 ${
                       selectedTags.includes(tag)
-                        ? "z-10 scale-105 border-primary bg-primary text-white shadow-xl shadow-primary/20"
+                        ? "z-10 scale-105 border-primary bg-primary-solid text-white shadow-xl shadow-primary/20"
                         : "border-border bg-card/50 text-muted-foreground backdrop-blur-sm hover:border-primary/50"
                     }`}
                   >
@@ -191,7 +191,7 @@ export function PortfolioContent() {
                           />
                           {isShowcase && (
                             <div className="absolute left-6 top-6">
-                              <span className="rounded-full bg-primary px-4 py-1.5 text-[10px] font-black uppercase tracking-widest text-white shadow-2xl">
+                              <span className="rounded-full bg-primary-solid px-4 py-1.5 text-[10px] font-black uppercase tracking-widest text-white shadow-2xl">
                                 Showcase Project
                               </span>
                             </div>

--- a/app/portfolio/[id]/ProjectDetailContent.tsx
+++ b/app/portfolio/[id]/ProjectDetailContent.tsx
@@ -63,7 +63,7 @@ export default function ProjectDetailContent({ project }: Props) {
             >
               <Link
                 href="/portfolio"
-                className="mb-4 inline-flex items-center gap-2 text-sm font-bold uppercase tracking-widest text-primary/80 transition-colors hover:text-primary"
+                className="mb-4 inline-flex items-center gap-2 text-sm font-bold uppercase tracking-widest text-primary transition-colors hover:text-primary/80"
               >
                 <ArrowLeftIcon className="h-4 w-4" />
                 Featured Project
@@ -444,17 +444,17 @@ export default function ProjectDetailContent({ project }: Props) {
           {project.incidents && project.incidents.length > 0 && (
             <section className="space-y-12">
               <div className="mx-auto mb-12 max-w-3xl space-y-4 text-center">
-                <p className="text-xs font-bold uppercase tracking-[0.3em] text-primary/80">
+                <p className="text-xs font-bold uppercase tracking-[0.3em] text-primary">
                   Incidents &amp; fixes
                 </p>
                 <h2 className="text-4xl font-black uppercase italic tracking-tight md:text-5xl">
                   Real bugs, real fixes
                 </h2>
                 <p className="text-lg leading-relaxed text-muted-foreground">
-                  The case-study sections above cover what the system does
-                  well. These are the times it didn&apos;t — what broke, what
-                  I got wrong on the first hypothesis, and how we confirmed
-                  the fix held.
+                  The case-study sections above cover what the system does well.
+                  These are the times it didn&apos;t — what broke, what I got
+                  wrong on the first hypothesis, and how we confirmed the fix
+                  held.
                 </p>
               </div>
 
@@ -502,7 +502,7 @@ export default function ProjectDetailContent({ project }: Props) {
                         </p>
                       </div>
                       <div className="space-y-2">
-                        <p className="text-xs font-black uppercase tracking-widest text-primary/70">
+                        <p className="text-xs font-black uppercase tracking-widest text-primary">
                           Confirmed by
                         </p>
                         <p className="leading-relaxed text-muted-foreground">
@@ -703,7 +703,7 @@ export default function ProjectDetailContent({ project }: Props) {
                     >
                       <div className="flex items-start gap-3">
                         <CheckIcon className="mt-0.5 h-5 w-5 text-primary opacity-50 transition-opacity group-hover:opacity-100" />
-                        <span className="group-hover:text-foreground text-muted-foreground transition-colors">
+                        <span className="text-muted-foreground transition-colors group-hover:text-foreground">
                           {feature}
                         </span>
                       </div>

--- a/components/author-box.tsx
+++ b/components/author-box.tsx
@@ -71,6 +71,7 @@ export default function AuthorBox({
               href={author.social.twitter}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${author.name} on Twitter`}
               className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
             >
               <TwitterIcon className="h-5 w-5" />
@@ -81,6 +82,7 @@ export default function AuthorBox({
               href={author.social.github}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${author.name} on GitHub`}
               className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
             >
               <GithubIcon className="h-5 w-5" />
@@ -91,6 +93,7 @@ export default function AuthorBox({
               href={author.social.linkedin}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${author.name} on LinkedIn`}
               className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-primary/10 hover:text-primary"
             >
               <LinkedinIcon className="h-5 w-5" />

--- a/components/blog/blog-layout.tsx
+++ b/components/blog/blog-layout.tsx
@@ -42,7 +42,7 @@ export function BlogLayout({ children, post }: BlogLayoutProps) {
       <div className="container mx-auto px-4 py-12 md:py-20">
         <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[1fr,320px]">
           <article
-            className="prose prose-invert duration-600 max-w-none transition-all ease-out"
+            className="duration-600 prose max-w-none transition-all ease-out dark:prose-invert"
             aria-labelledby="post-title"
           >
             <header className="mb-12 space-y-6">

--- a/components/featured-projects.tsx
+++ b/components/featured-projects.tsx
@@ -48,7 +48,7 @@ export function FeaturedProjects() {
 
                   <div className="absolute left-8 top-8 flex flex-col gap-3">
                     <div className="flex gap-2">
-                      <span className="rounded-full bg-primary px-4 py-1.5 text-[10px] font-black uppercase tracking-[0.2em] text-white shadow-2xl">
+                      <span className="rounded-full bg-primary-solid px-4 py-1.5 text-[10px] font-black uppercase tracking-[0.2em] text-white shadow-2xl">
                         Featured
                       </span>
                       <span className="rounded-full border border-white/10 bg-black/60 px-4 py-1.5 text-[10px] font-black uppercase tracking-[0.2em] text-white shadow-2xl backdrop-blur-xl">

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -9,7 +9,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+          "border-transparent bg-primary-solid text-primary-solid-foreground hover:bg-primary-solid/80",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -8,7 +8,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary-solid text-primary-solid-foreground hover:bg-primary-solid/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -30,6 +30,9 @@ const ROUTES = [
   "/portfolio/redis-battle-demo",
   "/contact",
   "/blogs",
+  // A representative blog post — exercises the prose body, code blocks and
+  // the author/share box (raw-HTML rendered content the listing pages skip).
+  "/blog/building-inventory-engine-never-oversells-concurrency",
   "/statistics",
 ];
 
@@ -55,12 +58,11 @@ test.describe("WCAG 2.1 AA — axe-core scan across public routes", () => {
 
         const results = await new AxeBuilder({ page })
           .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-          // Skip rules that have known false-positives on framer-motion
-          // animated containers + color-contrast on gradient backgrounds
-          // (handled visually instead).
-          .disableRules([
-            "color-contrast", // covered by manual review + Lighthouse a11y score
-          ])
+          // color-contrast is now ENFORCED (POR-1): the purple brand was
+          // decoupled into `--primary` (tuned for text/accents on the page
+          // background) and `--primary-solid` (dark enough for white text on
+          // buttons/badges) so both directions clear AA. Re-add a rule here
+          // only with a written justification.
           .analyze();
 
         // Group violations by impact for friendlier CI output
@@ -71,25 +73,29 @@ test.describe("WCAG 2.1 AA — axe-core scan across public routes", () => {
           (v) => v.impact === "moderate"
         );
 
-        expect.soft(
-          serious.map((v) => ({
-            id: v.id,
-            impact: v.impact,
-            help: v.help,
-            nodes: v.nodes.length,
-          })),
-          `serious/critical violations on ${route} (${theme})`
-        ).toEqual([]);
+        expect
+          .soft(
+            serious.map((v) => ({
+              id: v.id,
+              impact: v.impact,
+              help: v.help,
+              nodes: v.nodes.length,
+            })),
+            `serious/critical violations on ${route} (${theme})`
+          )
+          .toEqual([]);
 
-        expect.soft(
-          moderate.map((v) => ({
-            id: v.id,
-            impact: v.impact,
-            help: v.help,
-            nodes: v.nodes.length,
-          })),
-          `moderate violations on ${route} (${theme})`
-        ).toEqual([]);
+        expect
+          .soft(
+            moderate.map((v) => ({
+              id: v.id,
+              impact: v.impact,
+              help: v.help,
+              nodes: v.nodes.length,
+            })),
+            `moderate violations on ${route} (${theme})`
+          )
+          .toEqual([]);
 
         // Hard fail only on critical/serious — moderate are surfaced
         // as soft failures (visible in report, don't block merge yet)

--- a/lib/blog-typography.ts
+++ b/lib/blog-typography.ts
@@ -53,11 +53,20 @@ const blogTypography = plugin(function ({ addComponents, theme }: PluginAPI) {
       // Code Blocks
       pre: {
         background: "hsl(var(--card))",
+        // Explicit foreground so code text pairs with the card background in
+        // BOTH themes. Without this the @tailwindcss/typography base rule
+        // colors `pre code` a light slate (intended for its own dark pre-bg),
+        // which lands as light-on-white here and fails WCAG AA contrast.
+        color: "hsl(var(--foreground))",
         border: "1px solid hsl(var(--border))",
         "border-radius": theme("borderRadius.lg"),
         padding: "1.25rem",
         margin: "1.5rem 0",
         "overflow-x": "auto",
+      },
+      "pre code": {
+        color: "inherit",
+        background: "transparent",
       },
       code: {
         "font-family": theme("fontFamily.mono"),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,10 @@ module.exports = {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
         },
+        "primary-solid": {
+          DEFAULT: "hsl(var(--primary-solid))",
+          foreground: "hsl(var(--primary-solid-foreground))",
+        },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",


### PR DESCRIPTION
## What

Accessibility (WCAG AA) + perf sanity pass on the portfolio. The automated axe-core scan now reports **0 serious/critical violations** across 12 routes × light/dark × desktop/mobile (was several serious/critical).

## Root causes & fixes

**Purple brand couldn't satisfy contrast in both directions.** On the dark canvas, a single `--primary` token had to be *light* enough to read as text/links on the dark background (needs ≥4.5:1) **and** *dark* enough for white text on buttons/badges (also ≥4.5:1) — contradictory. At the old dark `65%` lightness, **both** failed (text-primary ≈4.36:1, white-on-primary ≈4.04:1). Decoupled into two semantic tokens:
- `--primary` — text/accents on the page background. Dark mode `65% → 72%` so `text-primary` *and* the app-wide `bg-primary/10` chip tint (purple-on-purple composites lower) clear 4.5:1.
- `--primary-solid` — solid fills that carry white text (buttons, badges, showcase/featured pills, active filter tab, skip-link, contact submit). Light unchanged (`55%`, so light-mode buttons look identical); dark `50%` → white text ≈7:1.

**Blog post code blocks were light-on-white in light mode.** `prose prose-invert` was applied unconditionally → switched to `prose dark:prose-invert`, and gave `.blog-content pre` an explicit `foreground` color so code pairs with the card background in both themes.

**Misc:** dropped opacity from small `text-primary/70|80` labels that dipped under 4.5:1; added `aria-label`s to the author-box social icon links (axe `link-name`).

**Gate change:** re-enabled the `color-contrast` rule in `e2e/a11y.spec.ts` (previously disabled) and added a representative `/blog/[slug]` route, so the contrast bar is genuinely enforced going forward.

## Verification (exact CI gate + e2e)
- `tsc --noEmit` → 0 errors
- `eslint . --ext .ts,.tsx` → clean
- `jest --ci` → **258 passed / 27 suites**
- `next build` → exit 0
- `e2e/a11y.spec.ts` (chromium + mobile-chrome, color-contrast enforced) → **48 passed**, 0 serious/critical

No new images added; existing pages already use `next/image`. Perf left as-is (no regressions introduced).