### PR TITLE
a11y: fix WCAG AA contrast on showcase detail pages + de-flake a11y gate

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -39,6 +39,13 @@
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    /* `--destructive` (above) is tuned as a button/badge BACKGROUND with
+       near-white foreground on top. When the showcase pages use red as
+       TEXT on the page background (e.g. "The Problem" headings, anti-pattern
+       labels) that value only clears ~3.5:1 — under WCAG AA. `--destructive-accent`
+       is the text-tuned red (mirrors the --primary / --primary-solid split from
+       POR-1): dark enough here for ≥4.5:1 on light surfaces. */
+    --destructive-accent: 0 74% 42%;
 
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
@@ -95,6 +102,9 @@
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
+    /* Text-tuned red for dark surfaces — light enough for ≥4.5:1 on the dark
+       card/background. See the light-theme note above. */
+    --destructive-accent: 0 91% 71%;
 
     --border: 217 32.6% 17.5%;
     --input: 217 32.6% 17.5%;

--- a/app/portfolio/[id]/ProjectDetailContent.tsx
+++ b/app/portfolio/[id]/ProjectDetailContent.tsx
@@ -156,9 +156,9 @@ export default function ProjectDetailContent({ project }: Props) {
               >
                 <div className="mb-2 flex items-center gap-3">
                   <div className="rounded-lg bg-destructive/10 p-2">
-                    <StarIcon className="h-5 w-5 rotate-45 text-destructive" />
+                    <StarIcon className="h-5 w-5 rotate-45 text-destructive-accent" />
                   </div>
-                  <h3 className="text-2xl font-bold text-destructive">
+                  <h3 className="text-2xl font-bold text-destructive-accent">
                     The Problem
                   </h3>
                 </div>
@@ -481,7 +481,7 @@ export default function ProjectDetailContent({ project }: Props) {
                     </header>
                     <div className="grid gap-10 px-8 py-8 md:grid-cols-2">
                       <div className="space-y-2">
-                        <p className="text-xs font-black uppercase tracking-widest text-destructive/80">
+                        <p className="text-xs font-black uppercase tracking-widest text-destructive-accent">
                           Symptom
                         </p>
                         <p className="leading-relaxed text-foreground">
@@ -630,9 +630,9 @@ export default function ProjectDetailContent({ project }: Props) {
               >
                 <div className="mb-2 flex items-center gap-3">
                   <div className="rounded-lg bg-destructive/10 p-2">
-                    <StarIcon className="h-5 w-5 rotate-45 text-destructive" />
+                    <StarIcon className="h-5 w-5 rotate-45 text-destructive-accent" />
                   </div>
-                  <h3 className="text-2xl font-bold text-destructive">
+                  <h3 className="text-2xl font-bold text-destructive-accent">
                     The Problem
                   </h3>
                 </div>

--- a/components/Showcase/StripeCaseStudy.tsx
+++ b/components/Showcase/StripeCaseStudy.tsx
@@ -149,8 +149,11 @@ const GLOW_BOTTOM =
 const GLOW_DESTRUCT =
   "pointer-events-none absolute -right-24 -bottom-24 h-72 w-72 rounded-full bg-destructive/10 blur-[120px]";
 const LABEL = "text-xs font-black uppercase tracking-[0.3em] text-primary";
+// A terminal-style code block. Pinned to a solid dark surface + light text in
+// BOTH themes — `bg-black/40` blended with the light-theme card to a muddy
+// mid-gray (#999) under which `text-muted-foreground` only read ~2:1 (WCAG AA fail).
 const CODE_BOX =
-  "overflow-x-auto rounded-xl border border-white/5 bg-black/40 p-4 font-mono text-xs leading-relaxed text-muted-foreground";
+  "overflow-x-auto rounded-xl border border-white/10 bg-zinc-900 p-4 font-mono text-xs leading-relaxed text-zinc-200";
 const REVEAL = {
   initial: { opacity: 0, y: 12 },
   whileInView: { opacity: 1, y: 0 },
@@ -445,10 +448,10 @@ redis> TTL stripe:event:evt_abc123
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-6">
               <div className="mb-4 flex items-center justify-between">
-                <p className="text-xs font-bold uppercase tracking-widest text-destructive">
+                <p className="text-xs font-bold uppercase tracking-widest text-destructive-accent">
                   Naive retry (wrong)
                 </p>
-                <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-destructive">
+                <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-destructive-accent">
                   anti-pattern
                 </span>
               </div>
@@ -472,7 +475,7 @@ throw new Error("out of retries");`}
                   "Missing idempotency key means each retry could double charge.",
                 ].map((line) => (
                   <li key={line} className="flex gap-2">
-                    <span className="text-destructive">&bull;</span>
+                    <span className="text-destructive-accent">&bull;</span>
                     <span>{line}</span>
                   </li>
                 ))}

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -28,6 +28,7 @@ const ROUTES = [
   "/portfolio/khatago",
   "/portfolio/stripe-payments-demo",
   "/portfolio/redis-battle-demo",
+  "/now",
   "/contact",
   "/blogs",
   // A representative blog post — exercises the prose body, code blocks and
@@ -45,6 +46,38 @@ async function setTheme(page: Page, theme: "light" | "dark") {
   await page.reload({ waitUntil: "networkidle" });
   // Give next-themes a moment to apply the class before axe scans
   await page.waitForTimeout(200);
+  await settleAnimations(page);
+}
+
+/**
+ * Force every framer-motion fade/slide-in to its final resting state before
+ * axe scans. Without this, axe occasionally samples a card mid-fade: the
+ * partially-transparent element blends with the white page so a `text-white`
+ * badge on `--primary-solid` reads as a lighter purple (#ad77f7 ≈ 3.1:1)
+ * and trips a *flaky* serious color-contrast failure — even though the badge
+ * clears AA (≥4.5:1) once opacity hits 1. Settling first removes the flake
+ * without masking any genuine at-rest contrast regression.
+ */
+async function settleAnimations(page: Page) {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0.001ms !important;
+        animation-delay: 0.001ms !important;
+        transition-duration: 0.001ms !important;
+        transition-delay: 0.001ms !important;
+      }
+    `,
+  });
+  await page.evaluate(() => {
+    document.querySelectorAll<HTMLElement>("[style]").forEach((el) => {
+      if (el.style.opacity && Number(el.style.opacity) < 1)
+        el.style.opacity = "1";
+      if (el.style.transform && el.style.transform !== "none")
+        el.style.transform = "none";
+    });
+  });
+  await page.waitForTimeout(150);
 }
 
 test.describe("WCAG 2.1 AA — axe-core scan across public routes", () => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ module.exports = {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        "destructive-accent": "hsl(var(--destructive-accent))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",


### PR DESCRIPTION
## What

A fresh QA confirmation sweep of the portfolio surfaced **real, stable WCAG AA color-contrast failures on the project detail pages** — the a11y gate was deterministically red (and partly flaky) on `main`.

### Findings & fixes

**1. `text-destructive` misused as foreground text** (eduscale, khatago, stripe-payments-demo, devtrack, redis-battle-demo — both themes)
`--destructive` holds shadcn's *button-background* red, but the showcase components use it as text color for "The Problem" headings, "Symptom"/"Naive retry" labels, anti-pattern badges and bullets.
- Light: `#ef4444`/`#f26969` on white → 2.99–3.53:1
- Dark: `#7f1d1d` on `#151728` → **1.76:1** (effectively invisible)

Added a text-tuned **`--destructive-accent`** token (light `0 74% 42%`, dark `0 91% 71%`) — mirrors the `--primary` / `--primary-solid` split from POR-1 — and switched the *text* usages to it. The base `--destructive` stays for fills/borders.

**2. StripeCaseStudy `CODE_BOX`** (stripe-payments-demo, light theme)
`bg-black/40 text-muted-foreground`: in light theme the translucent black blended with the card to a muddy `#999`, under which the muted text read ~2:1. Pinned the terminal block to a solid dark surface (`bg-zinc-900` / `text-zinc-200`) in **both** themes.

**3. Flaky a11y gate on `/portfolio` (light)**
axe occasionally sampled the "Showcase Project" badge mid fade-in, so its `--primary-solid` background read as a lighter, blended purple (~2.3–3.1:1) — a *false-positive* serious failure (~1 in 3 runs) that would intermittently block CI. Added a `settleAnimations()` step (disable transitions + force final opacity/transform) before each axe scan so the gate is deterministic. Also added `/now` to the scanned routes.

## Verification

- All detail pages clear AA in **both themes** — re-scanned 6× settled, **0 contrast nodes**.
- Full a11y suite **52/52** (chromium + mobile-chrome), and the formerly-flaky `/portfolio` light test passes **6/6** in isolation.
- `tsc` + `eslint` (0 errors) + `jest` (260/260) + `prettier --check` all green.
- Console-error + portfolio-detail e2e gates pass.
- Reviewed full-page screenshots (desktop + mobile + dark) of every page by eye — red accents now readable, no layout regressions.

## Scope note

This targets the pre-existing bug on `main`. The `/services` a11y route and a `/portfolio/grounded` capture route were intentionally **left out** — they depend on the pending `por-3-services-page` and `por-4-content-accuracy` branches; add them when those merge.