### PR TITLE
fix(blog): per-post branded OG covers instead of one shared placeholder

### DIFF
--- a/components/blog/blog-card.tsx
+++ b/components/blog/blog-card.tsx
@@ -45,6 +45,9 @@ export function BlogCard({ post, index }: BlogCardProps) {
   // Use a neutral project/preview image as the fallback for post previews so
   // the author's personal photo isn't used as a blog preview image.
   const imageSrc = post.image ?? "/Images/portfolio1.png";
+  // Generated OG covers (/api/og?...) are already final PNGs — skip the image
+  // optimizer (Next also blocks query-string srcs unless allow-listed).
+  const isGeneratedCover = imageSrc.startsWith("/api/og");
   const avatarSrc = post.author?.avatar ?? "/Images/shailesh.webp";
 
   return (
@@ -78,6 +81,7 @@ export function BlogCard({ post, index }: BlogCardProps) {
               fill
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
               className="object-cover transition-transform duration-500 group-hover:scale-110"
+              unoptimized={isGeneratedCover}
             />
             {post.tags && post.tags.length > 0 && (
               <div className="absolute bottom-4 left-4 z-20 flex gap-2">

--- a/lib/blog-data.ts
+++ b/lib/blog-data.ts
@@ -77,18 +77,37 @@ export const BLOG_SLUGS: string[] = [
   // "khatago-webhook-deduplication-receipt-pipeline",
 ];
 
+// Posts that never had a real cover historically all point at this shared
+// placeholder. Treat it (and an empty value) as "no cover" so we render a
+// branded, per-post OG image instead of the same generic screenshot 24×.
+const PLACEHOLDER_COVER = "/Images/portfolio1.png";
+
+/** Branded per-post cover via the OG image generator (title + gradient). */
+function generatedCover(title: string, description: string): string {
+  const params = new URLSearchParams({ title, type: "blog" });
+  if (description) params.set("description", description);
+  return `/api/og?${params.toString()}`;
+}
+
 function loadPost(slug: string): BlogPost | null {
   try {
     const filePath = join(process.cwd(), "content", "blog", `${slug}.mdx`);
     const raw = readFileSync(filePath, "utf8");
     const { data, content } = matter(raw);
+    const title = data.title ?? "";
+    const description = data.description ?? "";
+    const rawImage = data.image ?? "";
+    const image =
+      !rawImage || rawImage === PLACEHOLDER_COVER
+        ? generatedCover(title || slug, description)
+        : rawImage;
     return {
       slug,
-      title: data.title ?? "",
+      title,
       subtitle: data.subtitle,
-      description: data.description ?? "",
+      description,
       content,
-      image: data.image ?? "",
+      image,
       author: BLOG_AUTHOR,
       date: data.date ?? "",
       readTime: data.readTime ?? "",


### PR DESCRIPTION
From the pre-QA review (**PO-2**): all 24 blog posts shared one placeholder image (`/Images/portfolio1.png`, a generic code screenshot) — the "blogs look bad" issue.

## Fix
Each post now gets a **branded OG cover generated from its title** via the existing `/api/og` route (title + gradient + "Blog Post" label). Resolved in the **data layer** (`loadPost`) so the listing, home featured strip, and post pages all benefit — and every future post gets one automatically. A real per-post image still takes precedence if set (anything other than the placeholder).

- OG covers are already final PNGs → rendered with `unoptimized` (also sidesteps Next 16's query-string `localPatterns` restriction, which my build caught).

## Gate
lint + **268 tests** + build all green.

> Approach picked by you: generated OG covers (clean, per-post, no external deps) over hand-sourced stock. The same treatment can be applied to KhataGO's emoji blog covers next.