### PR TITLE
fix(accuracy): KhataGO has no Redis — describe the idempotency it actually has

### DIFF
--- a/constants/projects.ts
+++ b/constants/projects.ts
@@ -670,13 +670,12 @@ export const projects: Project[] = [
       "Function-calling",
       "i18n",
       "Node.js",
-      "Redis",
       "Webhook Idempotency",
     ],
     live: "https://khatago.vercel.app/",
     github: "https://github.com/Shailesh93602/khatago",
     detailedDescription:
-      "KhataGO is a WhatsApp-first bookkeeping platform for Indian MSMEs. The backend is a reconciliation pipeline: Meta webhooks arrive with at-least-once delivery, a Redis-backed idempotency guard drops duplicates, Gemini 2.0 Flash with function-calling parses both text ('Sold 500 to Ram') and receipt images (OCR → structured JSON with merchant/amount/date/line items) into 8 tool calls — create_transaction, create_receivable, record_payment_received, get_party_ledger, send_payment_reminder, and others — each mapped to a Prisma write. Results flow back to the user over WhatsApp; a CA portal exports Tally-ready XML vouchers for month-end close.",
+      "KhataGO is a WhatsApp-first bookkeeping platform for Indian MSMEs. The backend is a reconciliation pipeline: Meta webhooks arrive with at-least-once delivery, and idempotency is enforced in Postgres rather than a cache — a unique constraint on the WhatsApp message id rejects duplicate deliveries, and a conditional UPDATE (PENDING→PROCESSING) atomically claims each message so concurrent redeliveries produce exactly one Gemini run instead of a double ledger write. Gemini 2.0 Flash with function-calling parses both text ('Sold 500 to Ram') and receipt images (OCR → structured JSON with merchant/amount/date/line items) into 10 tool calls — create_transaction, create_receivable, record_payment_received, get_party_ledger, send_payment_reminder, and others — each mapped to a Prisma write. Results flow back to the user over WhatsApp; a CA portal exports Tally-ready XML vouchers for month-end close.",
     architecture: {
       layers: [
         {
@@ -684,7 +683,7 @@ export const projects: Project[] = [
           items: [
             "WhatsApp Cloud API webhook (Meta)",
             "HMAC verify + x-hub-signature check",
-            "Redis-backed dedup (message-id hash, TTL window)",
+            "DB-enforced dedup (unique waMessageId) + atomic PENDING→PROCESSING claim",
           ],
         },
         {
@@ -719,14 +718,14 @@ export const projects: Project[] = [
     },
     keyMetrics: [
       {
-        label: "Ingress dedup",
-        value: "< 1ms",
+        label: "Duplicate webhooks",
+        value: "0 double-writes",
         description:
-          "Redis-backed message-id hash lookup drops duplicate Meta webhooks before any LLM call",
+          "Unique waMessageId + an atomic PENDING→PROCESSING claim drop Meta's redeliveries before any LLM call",
       },
       {
         label: "Tool calls",
-        value: "8",
+        value: "10",
         description:
           "Gemini function-calling surface: transactions, receivables, payments, ledgers, reminders",
       },
@@ -748,7 +747,7 @@ export const projects: Project[] = [
     techStack: [
       "Frontend: Next.js (App Router), React, Tailwind CSS, Recharts, i18next",
       "Backend: Node.js, Express (TypeScript), Prisma ORM, PostgreSQL",
-      "AI & Messaging: Google Gemini AI, WhatsApp Cloud API, Redis/Bull Queues",
+      "AI & Messaging: Google Gemini AI (function-calling + Vision OCR), WhatsApp Cloud API",
       "Infrastructure: Supabase (Auth & Real-time), Vercel",
     ],
     problem:
@@ -756,7 +755,7 @@ export const projects: Project[] = [
     solution:
       "A 'zero-learning-curve' platform that works where the user already is: WhatsApp. By combining the simplicity of chat with the power of AI, KhataGO makes business accounting as easy as sending a message.",
     challengesSolved:
-      "Meta's WhatsApp Cloud API sends duplicate webhook events. The deduplication layer hashes the incoming message ID and checks a Redis TTL window before processing — duplicate events are dropped in under 1ms. The Gemini AI OCR pipeline downloads the WhatsApp image URL, sends it to Gemini Vision, and maps the extracted JSON (merchant, amount, date, line items) to a ledger transaction. Tally XML export is non-trivial: Tally's voucher schema requires specific date formatting, ledger name lookups, and GST field structure — wrong XML silently fails to import. Bull queues decouple all three operations so the WhatsApp bot responds immediately while processing happens in the background.",
+      "Meta's WhatsApp Cloud API delivers at least once, so the same message arrives twice — and an LLM call is expensive enough that deduplicating after it is too late. Idempotency lives in Postgres instead of a cache: the message id is a unique column, so a duplicate insert fails at the DB, and processing starts with a conditional UPDATE that flips aiStatus PENDING→PROCESSING only if it is still PENDING. If that update changes zero rows, another delivery already claimed the message and this one exits — concurrent redeliveries yield exactly one Gemini run and one ledger write, with no cache to fall out of sync with the audit row. The webhook acknowledges Meta immediately and the AI work runs after the response, so a burst never times out the handler. The Gemini OCR pipeline downloads the WhatsApp image, sends it to Gemini Vision, and maps the extracted JSON (merchant, amount, date, line items) to a ledger transaction. Tally XML export is the fiddly part: the voucher schema needs specific date formatting, ledger name lookups, and GST field structure — wrong XML silently fails to import, so it is covered by 19 unit tests.",
     userFlow: [
       {
         step: "Onboarding",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -104,16 +104,16 @@ Developer intelligence dashboard:
 
 ### KhataGO
 **Live:** https://khatago.vercel.app/
-**Stack:** Next.js, TypeScript, Prisma, PostgreSQL (Supabase), Gemini AI, WhatsApp Cloud API, Redis, Bull Queues, i18next, Node.js, Express.js
+**Stack:** Next.js, TypeScript, Prisma, PostgreSQL (Supabase), Gemini AI, WhatsApp Cloud API, i18next, Node.js
 **Note:** Source code is private.
 
 WhatsApp-first AI accounting platform for Indian SMBs:
 
 **Technical depth:**
-- **WhatsApp webhook deduplication:** Meta sends duplicate events. Each incoming message ID is hashed and checked against a Redis TTL window before processing — duplicates dropped in <1ms.
+- **WhatsApp webhook idempotency (no cache):** Meta delivers at least once. The WhatsApp message id is a unique column, so a duplicate insert fails at the database; processing then begins with a conditional UPDATE flipping aiStatus PENDING→PROCESSING only if it is still PENDING. Zero rows changed means another delivery already claimed it, so concurrent redeliveries produce exactly one Gemini run and one ledger write — and idempotency can never drift from the audit row the way a separate cache can.
 - **Gemini AI OCR pipeline:** WhatsApp image URL → download to buffer → Gemini Vision API → structured JSON (merchant, amount, date, line items) → ledger transaction. Error handling for low-confidence extractions.
 - **Tally XML export:** Generates TALLYMESSAGE XML vouchers for accountants. Non-trivial: Tally requires specific date format, ledger name lookup from master data, and precise GST field structure. Wrong XML silently fails to import.
-- **Bull queues:** All three operations (webhook processing, OCR, XML generation) are decoupled via Bull so the WhatsApp bot responds immediately (<500ms) while processing happens asynchronously.
+- **Fast webhook ack:** The handler persists the message and returns to Meta immediately, then runs the Gemini work after the response — so a burst of deliveries never times out the webhook, without introducing a queue broker.
 - **i18next:** Full UI in English, Hindi, and Gujarati.
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -25,7 +25,7 @@ Live:
 
 - [EduScale](https://eduscale.vercel.app/): Real-time engineering learning platform with 1v1 coding battles. Backend uses @socket.io/redis-adapter (horizontal Socket.io scaling), redlock (distributed locks preventing duplicate battle starts), opossum (circuit breaker around code execution), prom-client (Prometheus /metrics), Bull queues. Stack: Next.js 15, React 19, TypeScript, Node.js, Express, Prisma, PostgreSQL, Redis, Supabase Auth.
 - [DevTrack](https://daily-dev-track.vercel.app): Developer productivity dashboard. Supabase Realtime postgres_changes subscription on daily_logs for live activity feed + sub-second multi-tab sync. Stack: Next.js, TypeScript, Prisma, PostgreSQL, Supabase Realtime, Recharts.
-- [KhataGO](https://khatago.vercel.app/): WhatsApp-first AI accounting for Indian SMBs. WhatsApp Business webhook with Redis deduplication, Gemini AI function-calling for receipt OCR → structured transactions + receivables management. Stack: Next.js, Gemini AI SDK, WhatsApp Cloud API, PostgreSQL (Prisma), Redis, i18n (en/hi/gu).
+- [KhataGO](https://khatago.vercel.app/): WhatsApp-first AI accounting for Indian SMBs. WhatsApp Business webhook with DB-enforced idempotency (unique message id + an atomic PENDING→PROCESSING claim, no cache in the path), Gemini AI function-calling for receipt OCR → structured transactions + receivables management. Stack: Next.js, Gemini AI SDK, WhatsApp Cloud API, PostgreSQL (Prisma), i18n (en/hi/gu).
 
 Open-source / demo:
 

--- a/scripts/check-live-urls.mjs
+++ b/scripts/check-live-urls.mjs
@@ -33,14 +33,31 @@ const RETRY_DELAY_MS = 5_000;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
- * URLs allowed to 404 without failing the script.
- * Typically private GitHub repos that are pending a public-flip —
- * remove entries here as each repo goes public.
+ * URLs allowed to 404 without failing the script — private GitHub repos
+ * pending a public-flip.
  *
- * Leaving an entry here for too long defeats the purpose of the check,
- * so treat this as a 7-day maximum.
+ * Each entry carries an EXPIRY. A grace period that never ends is just a
+ * silenced alarm: the khatago entry sat here for ~6 weeks while the
+ * recruiter-facing Repository link 404'd and this check reported green every
+ * day. Past its expiry an entry stops being a free pass and fails the run, so
+ * the decision (flip the repo public, or drop the link from projects.ts) comes
+ * back to the surface instead of rotting.
  */
-const KNOWN_PRIVATE = new Set(["https://github.com/Shailesh93602/khatago"]);
+const KNOWN_PRIVATE = new Map([
+  [
+    "https://github.com/Shailesh93602/khatago",
+    { until: "2026-08-29", note: "flip public or remove the link" },
+  ],
+]);
+
+const today = new Date().toISOString().slice(0, 10);
+
+/** An allow-list entry only counts while it hasn't expired. */
+function allowance(url) {
+  const entry = KNOWN_PRIVATE.get(url);
+  if (!entry) return null;
+  return { ...entry, expired: today > entry.until };
+}
 
 /**
  * Some "live" URLs are APIs whose root path 404s by design (no `GET /` route).
@@ -165,11 +182,17 @@ function statusIcon(ok, allowed) {
 }
 
 for (const r of results) {
-  const allowed = KNOWN_PRIVATE.has(r.url);
+  const grace = allowance(r.url);
+  const allowed = Boolean(grace) && !grace.expired;
   const icon = statusIcon(r.ok, allowed);
   const statusStr = r.status > 0 ? String(r.status) : "ERR";
   const nameCol = r.name.padEnd(maxName + 2);
-  const suffix = !r.ok && allowed ? "  (allowed: pending public-flip)" : "";
+  let suffix = "";
+  if (!r.ok && grace) {
+    suffix = grace.expired
+      ? `  (grace expired ${grace.until} — ${grace.note})`
+      : `  (allowed until ${grace.until}: pending public-flip)`;
+  }
   const line = `${icon}  ${nameCol} ${statusStr.padEnd(6)} ${r.ms}ms  ${r.url}${suffix}`;
   if (r.ok || allowed) {
     console.log(line);
@@ -180,8 +203,13 @@ for (const r of results) {
 
 console.log("─".repeat(70));
 
-const failed = results.filter((r) => !r.ok && !KNOWN_PRIVATE.has(r.url));
-const allowedFailed = results.filter((r) => !r.ok && KNOWN_PRIVATE.has(r.url));
+const stillAllowed = (r) => {
+  const grace = allowance(r.url);
+  return Boolean(grace) && !grace.expired;
+};
+
+const failed = results.filter((r) => !r.ok && !stillAllowed(r));
+const allowedFailed = results.filter((r) => !r.ok && stillAllowed(r));
 
 if (allowedFailed.length > 0) {
   console.log(


### PR DESCRIPTION
## The problem

The portfolio told recruiters — and AI crawlers, via `llms.txt` — that KhataGO drops duplicate webhooks with **"a Redis-backed idempotency guard"** in **"under 1ms"**, and decouples work with **"Bull queues"**.

There is no `redis` and no `bull` dependency in the KhataGO repo. Neither has ever existed.

What actually exists is better: idempotency is enforced in Postgres. The WhatsApp message id is a unique column, so a duplicate insert fails at the database, and processing begins with a conditional `UPDATE` flipping `aiStatus` PENDING→PROCESSING only if it is still PENDING. Zero rows changed means another delivery already claimed the message, so concurrent redeliveries produce exactly one Gemini run and one ledger write — with no cache that can drift out of sync with the audit row.

So the fabrication was trading a defensible answer for one that collapses on the first follow-up question. "Tell me about the Redis guard" has no good ending.

## Changed

- **`constants/projects.ts`** — description, architecture ingress layer, key metric, techStack, `challengesSolved`, and the `Redis` tag. Also `8` → `10` tool calls (`lib/ai/tools.ts` defines 10).
- **`public/llms.txt` + `llms-full.txt`** — same corrections where AI crawlers read them.
- **`scripts/check-live-urls.mjs`** — `KNOWN_PRIVATE` entries now carry an expiry.

## Why the URL check needed a change

It already knew: `github.com/Shailesh93602/khatago` was allow-listed with a comment saying *"treat this as a 7-day maximum."* The entry has been there ~6 weeks. The daily cron reported green every day while the recruiter-facing Repository link returned 404 — a grace period with no way to end is just a silenced alarm. Entries now expire (khatago: 2026-08-29), after which the run fails and the decision — flip the repo public, or drop the link — surfaces again.

## Two things this pass found that need you

1. **`holdfast-50gt.onrender.com` is not responding at all** — not a slow cold start; no HTTP response in 120s. That is the flagship project's live link, and it's on the portfolio. Needs the Render dashboard.
2. **KhataGO is the only private repo of the 11 linked** (all 10 others return 200). Flip it public or drop the link before Aug 29.

## Gate

type-check ✓ · lint ✓ (3 pre-existing `no-console` warnings, untouched) · **268 tests** ✓ · build ✓ · prettier ✓ on changed files