### PR TITLE
fix(mobile): stop every page swiping a full screen sideways

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,15 +131,37 @@
   * {
     @apply border-border;
   }
+  /* Horizontal-scroll containment.
+   *
+   * The mobile nav drawer is `fixed inset-0` translated to `translate-x-full`
+   * when closed, so it sits exactly one viewport to the right. That makes the
+   * document scrollWidth exactly 2x the viewport and every page swipes sideways
+   * on a phone.
+   *
+   * This used to be `overflow-x: clip` on `body` ALONE, and it silently did
+   * nothing — computed style on the live page read `overflow-x: visible`. The
+   * reason is a CSS rule that is easy to miss: when `html` has
+   * `overflow: visible`, the BODY's overflow is propagated to the viewport, and
+   * body's own used value becomes `visible`. So the declaration was applying to
+   * an element that had been told to stop honouring it.
+   *
+   * Setting it on `html` too gives the viewport a real clipping context.
+   *
+   * `clip`, not `hidden`, on purpose: `hidden` makes the element a scroll
+   * container, which breaks `position: sticky` on the navbar and changes what
+   * `scrollIntoView` does. `clip` clips without creating a scrollport.
+   *
+   * Guarded by e2e/mobile-overflow.spec.ts — asserts scrollWidth never exceeds
+   * the viewport on any route at 390px, so this cannot silently regress again.
+   */
+  html {
+    overflow-x: clip;
+  }
   body {
     @apply bg-background text-foreground;
     font-feature-settings:
       "rlig" 1,
       "calt" 1;
-    /* The mobile nav drawer lives at translate-x-full off-screen when closed,
-       which technically extends document scrollWidth past viewport on mobile.
-       overflow-x: clip keeps the drawer's transition intact while preventing
-       horizontal page scroll. */
     overflow-x: clip;
   }
 }

--- a/components/navbar/index.tsx
+++ b/components/navbar/index.tsx
@@ -102,52 +102,69 @@ export default function Navbar() {
       {/* `inert` when closed removes the whole subtree from the focus order —
           prevents axe aria-hidden-focus failures that used to fire because the
           close button + nav links remained tab-reachable inside an aria-hidden region. */}
-      <div
-        className={`fixed inset-0 z-[999] flex h-[100vh] transform flex-col border-l border-border/40 bg-background/95 backdrop-blur-sm transition-transform duration-300 ease-out md:hidden ${
-          menuOpen
-            ? "translate-x-0 opacity-100"
-            : "pointer-events-none translate-x-full opacity-0"
-        }`}
-        aria-hidden={!menuOpen}
-        inert={!menuOpen}
-      >
-        <div className="flex items-center justify-between border-b px-6 py-5">
-          <Link
-            href="/"
-            className="text-gradient text-xl font-bold"
-            onClick={closeMenu}
-          >
-            <span>SC</span>
-          </Link>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={closeMenu}
-            aria-label="Close menu"
-            className="hover:bg-muted"
-          >
-            <XIcon className="h-6 w-6" />
-          </Button>
+      {/* The drawer sits inside a fixed, viewport-sized clipping wrapper.
+
+          Why the wrapper exists: the drawer is parked at `translate-x-full` when
+          closed, i.e. exactly one viewport to the right. A `position: fixed`
+          element is attached to the viewport rather than to any ancestor, so no
+          amount of `overflow-x: clip` on html/body could clip it — and the
+          document's scrollWidth came out at exactly 2x the viewport, which made
+          every page on the site swipe sideways on a phone.
+
+          Making the wrapper `fixed` and the drawer `absolute` inside it means
+          the wrapper is now the drawer's containing block, so `overflow-x: clip`
+          on the wrapper actually contains it. The slide transition is unchanged.
+
+          `pointer-events-none` on the wrapper with `pointer-events-auto` on the
+          open drawer keeps the rest of the page clickable through it. */}
+      <div className="pointer-events-none fixed inset-0 z-[999] overflow-x-clip md:hidden">
+        <div
+          className={`absolute inset-0 flex h-full transform flex-col border-l border-border/40 bg-background/95 backdrop-blur-sm transition-transform duration-300 ease-out ${
+            menuOpen
+              ? "pointer-events-auto translate-x-0 opacity-100"
+              : "pointer-events-none translate-x-full opacity-0"
+          }`}
+          aria-hidden={!menuOpen}
+          inert={!menuOpen}
+        >
+          <div className="flex items-center justify-between border-b px-6 py-5">
+            <Link
+              href="/"
+              className="text-gradient text-xl font-bold"
+              onClick={closeMenu}
+            >
+              <span>SC</span>
+            </Link>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={closeMenu}
+              aria-label="Close menu"
+              className="hover:bg-muted"
+            >
+              <XIcon className="h-6 w-6" />
+            </Button>
+          </div>
+          <nav className="flex flex-1 items-center justify-center">
+            <ul className="w-full space-y-6 px-6">
+              {navigation.map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={`block rounded-lg px-4 py-3 text-base font-medium transition-colors ${
+                      isActive(item.href)
+                        ? "font-bold text-primary"
+                        : "text-foreground hover:bg-muted/80 hover:text-primary"
+                    }`}
+                    onClick={closeMenu}
+                  >
+                    {item.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
         </div>
-        <nav className="flex flex-1 items-center justify-center">
-          <ul className="w-full space-y-6 px-6">
-            {navigation.map((item) => (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  className={`block rounded-lg px-4 py-3 text-base font-medium transition-colors ${
-                    isActive(item.href)
-                      ? "font-bold text-primary"
-                      : "text-foreground hover:bg-muted/80 hover:text-primary"
-                  }`}
-                  onClick={closeMenu}
-                >
-                  {item.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </nav>
       </div>
     </nav>
   );

--- a/e2e/mobile-overflow.spec.ts
+++ b/e2e/mobile-overflow.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+import { ALL_ROUTES } from "./routes";
+
+/**
+ * Mobile horizontal-scroll gate.
+ *
+ * Every page on this site used to swipe a full screen sideways on a phone. The
+ * cause was the mobile nav drawer: `fixed inset-0` parked at `translate-x-full`
+ * when closed, so it sat exactly one viewport to the right and the document's
+ * scrollWidth came out at exactly 2x the viewport.
+ *
+ * Two earlier attempts to fix it did not hold, which is why this test exists in
+ * this shape. Both failed for the same reason — they clamped `overflow-x` on
+ * `html`/`body`, and a `position: fixed` element is attached to the viewport, so
+ * no ancestor's overflow can clip it. (Worse, setting `overflow-x` on `body`
+ * alone gets propagated to the viewport, leaving body's own used value
+ * `visible` — the declaration was applying to an element that had been told to
+ * stop honouring it.) The real fix makes the drawer `absolute` inside a `fixed`
+ * clipping wrapper, so the wrapper becomes its containing block.
+ *
+ * The assertion is deliberately on OBSERVED SCROLL, not just on scrollWidth: a
+ * page can report a wide scrollWidth and still be unscrollable, and it is the
+ * scrolling a user's thumb does that matters.
+ */
+
+const MOBILE = { width: 390, height: 844 };
+
+test.describe("mobile: no horizontal scroll", () => {
+  test.use({ viewport: MOBILE });
+
+  for (const route of ALL_ROUTES) {
+    test(`${route} does not scroll sideways at ${MOBILE.width}px`, async ({ page }) => {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await page.waitForLoadState("networkidle").catch(() => {});
+
+      const result = await page.evaluate(() => {
+        const viewportWidth = document.documentElement.clientWidth;
+        // Try to scroll right as far as possible, then read where we ended up.
+        window.scrollTo(99999, 0);
+        const scrolledX = window.scrollX;
+        window.scrollTo(0, 0);
+        return {
+          viewportWidth,
+          scrollWidth: document.documentElement.scrollWidth,
+          scrolledX,
+        };
+      });
+
+      expect(
+        result.scrolledX,
+        `page scrolled ${result.scrolledX}px sideways — a user can swipe the layout off-screen`,
+      ).toBe(0);
+
+      // 1px of slack for sub-pixel rounding on fractional layouts.
+      expect(
+        result.scrollWidth,
+        `scrollWidth ${result.scrollWidth} exceeds viewport ${result.viewportWidth}`,
+      ).toBeLessThanOrEqual(result.viewportWidth + 1);
+    });
+  }
+
+  test("the nav drawer still opens, and still closes", async ({ page }) => {
+    // The fix must not have been achieved by breaking the drawer — the cheapest
+    // way to stop an off-screen element overflowing is to stop rendering it.
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const openButton = page.getByRole("button", { name: /open menu/i });
+    await expect(openButton).toBeVisible();
+    await openButton.click();
+
+    const drawerLink = page.getByRole("link", { name: "Portfolio", exact: true });
+    await expect(drawerLink).toBeVisible();
+
+    await page.getByRole("button", { name: /close menu/i }).click();
+    await expect(drawerLink).toBeHidden();
+
+    // And closing it must not have reintroduced the overflow.
+    const scrolledX = await page.evaluate(() => {
+      window.scrollTo(99999, 0);
+      const x = window.scrollX;
+      window.scrollTo(0, 0);
+      return x;
+    });
+    expect(scrolledX, "closing the drawer reintroduced horizontal scroll").toBe(0);
+  });
+});


### PR DESCRIPTION
Every route scrolled **exactly one viewport** horizontally on a phone. Measured before: `scrollWidth` 780 against a 390px viewport, `window.scrollX` reaching 390 after a swipe.

## Root cause

The mobile nav drawer is `fixed inset-0` parked at `translate-x-full` when closed — so it sits exactly one viewport to the right. That is where the factor of two came from.

## Why the two earlier attempts didn't hold

Both clamped `overflow-x` on `html` / `body`. **A `position: fixed` element is attached to the viewport, not to any ancestor, so no ancestor's overflow can clip it.**

The previous fix was inert twice over: setting `overflow-x` on `body` *alone* gets propagated to the viewport, which leaves body's own used value as `visible`. Live computed style confirmed `body { overflow-x: visible }` even though the rule was right there in `globals.css` — the declaration was applying to an element that had been told to stop honouring it.

## The fix

Make the drawer `absolute` inside a `fixed` clipping wrapper. The wrapper becomes the drawer's containing block, so its `overflow-x: clip` actually contains it. The slide transition is unchanged.

`clip` rather than `hidden` throughout — `hidden` would make the element a scroll container and break `position: sticky` on the navbar.

## After

`scrollWidth` 390, `scrollX` **0**, on all 22 routes.

## The regression test

`e2e/mobile-overflow.spec.ts` asserts **observed scroll**, not just `scrollWidth` — a page can report a wide `scrollWidth` and still be unscrollable, and what matters is what a thumb actually does.

It also asserts the drawer still opens and closes. The cheapest way to stop an off-screen element overflowing is to stop rendering it, and that would be a regression wearing a fix's clothing.

**22 passed** · type-check ✓ · lint ✓ (3 pre-existing `no-console` warnings) · 269 unit ✓