### PR TITLE
chore: enforce Prettier in CI and fix the 26 files that had drifted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Lint
         run: npx eslint . --ext .ts,.tsx
 
+      # Formatting is checked in CI because it does not hold otherwise. This
+      # step was added after 26 files had drifted out of Prettier style: the
+      # scripts existed, nothing ran them, and the diff noise landed in
+      # unrelated reviews. A check that is not enforced is a suggestion.
+      - name: Format check
+        run: npm run format:check
+
       - name: Unit tests
         run: npm test -- --ci --coverage
 

--- a/__tests__/faq-section.test.tsx
+++ b/__tests__/faq-section.test.tsx
@@ -16,7 +16,7 @@ describe("FAQSection", () => {
   it("renders the section heading", () => {
     render(<FAQSection items={sample} />);
     expect(
-      screen.getByRole("heading", { name: /frequently asked questions/i }),
+      screen.getByRole("heading", { name: /frequently asked questions/i })
     ).toBeInTheDocument();
   });
 

--- a/__tests__/hooks.test.tsx
+++ b/__tests__/hooks.test.tsx
@@ -140,4 +140,3 @@ describe("useBlogPosts", () => {
     expect(secondUrl).toContain("search=redis");
   });
 });
-

--- a/__tests__/statistics-snapshot.test.ts
+++ b/__tests__/statistics-snapshot.test.ts
@@ -30,8 +30,16 @@ describe("getStatisticsSnapshot", () => {
         forks: 1,
         followers: 5,
         languages: [{ name: "TypeScript", percentage: 60, color: "#3178c6" }],
-        currentStreak: { count: 9, startDate: "2026-04-10", endDate: "2026-04-18" },
-        longestStreak: { count: 42, startDate: "2025-01-01", endDate: "2025-02-11" },
+        currentStreak: {
+          count: 9,
+          startDate: "2026-04-10",
+          endDate: "2026-04-18",
+        },
+        longestStreak: {
+          count: 42,
+          startDate: "2025-01-01",
+          endDate: "2025-02-11",
+        },
         totalCommits: 4758,
         totalPRs: 120,
         totalIssues: 40,
@@ -65,9 +73,7 @@ describe("getStatisticsSnapshot", () => {
   });
 
   it("caches after first read — subsequent calls do not re-read the file", () => {
-    readFileSync.mockReturnValue(
-      JSON.stringify({ github: {}, leetcode: {} })
-    );
+    readFileSync.mockReturnValue(JSON.stringify({ github: {}, leetcode: {} }));
 
     const { getStatisticsSnapshot } = loadFreshModule();
     getStatisticsSnapshot();

--- a/app/about/AboutContent.tsx
+++ b/app/about/AboutContent.tsx
@@ -62,7 +62,7 @@ export default function AboutContent() {
               </h2> */}
               <motion.p
                 variants={itemVariants}
-                className="text-muted-foreground text-lg leading-relaxed"
+                className="text-lg leading-relaxed text-muted-foreground"
               >
                 I&apos;m a Software Engineer from Patan, Gujarat, currently
                 based in Ahmedabad. At ContextQA I work on the backend of our
@@ -96,7 +96,7 @@ export default function AboutContent() {
                   <HobbiesSection />
                   <motion.blockquote
                     variants={itemVariants}
-                    className="text-muted-foreground my-8 border-l-4 border-primary py-4 pl-6 text-lg italic"
+                    className="my-8 border-l-4 border-primary py-4 pl-6 text-lg italic text-muted-foreground"
                   >
                     &quot;Code is like humor. When you have to explain it,
                     it&apos;s bad.&quot;
@@ -111,7 +111,7 @@ export default function AboutContent() {
               onClick={() => setShowFullContent(!showFullContent)}
               aria-expanded={showFullContent}
             >
-              <span className="text-foreground mr-2 text-lg font-semibold">
+              <span className="mr-2 text-lg font-semibold text-foreground">
                 {showFullContent ? "Show Less" : "Show More"}
               </span>
               {showFullContent ? (

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -5,26 +5,24 @@ export const contentType = "image/png";
 
 export default function AppleIcon() {
   return new ImageResponse(
-    (
-      <div
-        style={{
-          fontSize: 110,
-          fontWeight: 800,
-          background: "linear-gradient(135deg,#0f0f0f 0%,#1a1a2e 100%)",
-          color: "#ffffff",
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          letterSpacing: "-4px",
-          borderRadius: 30,
-          fontFamily: "sans-serif",
-        }}
-      >
-        SC
-      </div>
-    ),
+    <div
+      style={{
+        fontSize: 110,
+        fontWeight: 800,
+        background: "linear-gradient(135deg,#0f0f0f 0%,#1a1a2e 100%)",
+        color: "#ffffff",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        letterSpacing: "-4px",
+        borderRadius: 30,
+        fontFamily: "sans-serif",
+      }}
+    >
+      SC
+    </div>,
     size
   );
 }

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -5,25 +5,23 @@ export const contentType = "image/png";
 
 export default function Icon() {
   return new ImageResponse(
-    (
-      <div
-        style={{
-          fontSize: 20,
-          fontWeight: 800,
-          background: "linear-gradient(135deg,#0f0f0f 0%,#1a1a2e 100%)",
-          color: "#ffffff",
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          letterSpacing: "-1px",
-          fontFamily: "sans-serif",
-        }}
-      >
-        SC
-      </div>
-    ),
+    <div
+      style={{
+        fontSize: 20,
+        fontWeight: 800,
+        background: "linear-gradient(135deg,#0f0f0f 0%,#1a1a2e 100%)",
+        color: "#ffffff",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        letterSpacing: "-1px",
+        fontFamily: "sans-serif",
+      }}
+    >
+      SC
+    </div>,
     size
   );
 }

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -48,7 +48,9 @@ export default function Projects() {
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqToSchema(faqItems)) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqToSchema(faqItems)),
+        }}
       />
       <PortfolioContent />
       <FAQSection

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,14 +10,62 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const ogFor = (path: string) =>
     `${SITE_URL}/api/og?title=${encodeURIComponent("Shailesh Chaudhari")}&type=page&description=${encodeURIComponent(path)}`;
   const staticRoutes: MetadataRoute.Sitemap = [
-    { url: `${SITE_URL}/`, lastModified: new Date(), changeFrequency: "weekly", priority: 1, images: [`${SITE_URL}/Images/shailesh.webp`] },
-    { url: `${SITE_URL}/blogs`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9, images: [ogFor("/blogs")] },
-    { url: `${SITE_URL}/about`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.9, images: [`${SITE_URL}/Images/shailesh.webp`] },
-    { url: `${SITE_URL}/contact`, lastModified: new Date(), changeFrequency: "yearly", priority: 0.6, images: [ogFor("/contact")] },
-    { url: `${SITE_URL}/portfolio`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.95, images: [ogFor("/portfolio")] },
-    { url: `${SITE_URL}/services`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.9, images: [ogFor("/services")] },
-    { url: `${SITE_URL}/statistics`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7, images: [ogFor("/statistics")] },
-    { url: `${SITE_URL}/now`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7, images: [ogFor("/now")] },
+    {
+      url: `${SITE_URL}/`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+      images: [`${SITE_URL}/Images/shailesh.webp`],
+    },
+    {
+      url: `${SITE_URL}/blogs`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+      images: [ogFor("/blogs")],
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+      images: [`${SITE_URL}/Images/shailesh.webp`],
+    },
+    {
+      url: `${SITE_URL}/contact`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.6,
+      images: [ogFor("/contact")],
+    },
+    {
+      url: `${SITE_URL}/portfolio`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.95,
+      images: [ogFor("/portfolio")],
+    },
+    {
+      url: `${SITE_URL}/services`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+      images: [ogFor("/services")],
+    },
+    {
+      url: `${SITE_URL}/statistics`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+      images: [ogFor("/statistics")],
+    },
+    {
+      url: `${SITE_URL}/now`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+      images: [ogFor("/now")],
+    },
   ];
 
   // Dynamic blog post routes — `images` is a Google Discover ranking signal

--- a/components/Achievements/index.tsx
+++ b/components/Achievements/index.tsx
@@ -31,7 +31,7 @@ export default function AchievementsSection() {
 
   return (
     <motion.div variants={itemVariants}>
-      <h3 className="text-foreground mb-6 flex items-center text-2xl font-semibold">
+      <h3 className="mb-6 flex items-center text-2xl font-semibold text-foreground">
         <TrophyIcon className="mr-2 h-6 w-6 text-primary" />
         Achievements
       </h3>
@@ -49,7 +49,7 @@ export default function AchievementsSection() {
               <div className="flex items-start">
                 {getIcon(achievement.iconName)}
                 <div>
-                  <h4 className="text-foreground text-lg font-semibold">
+                  <h4 className="text-lg font-semibold text-foreground">
                     {achievement.title}
                   </h4>
                   <p className="text-muted-foreground">

--- a/components/EducationSection/index.tsx
+++ b/components/EducationSection/index.tsx
@@ -8,7 +8,7 @@ import { education, itemVariants } from "@/constants";
 export function EducationSection() {
   return (
     <motion.div variants={itemVariants}>
-      <h3 className="text-foreground mb-8 flex items-center text-2xl font-semibold">
+      <h3 className="mb-8 flex items-center text-2xl font-semibold text-foreground">
         <GraduationCapIcon className="mr-3 h-7 w-7 text-primary" />
         Education
       </h3>
@@ -65,7 +65,7 @@ export function EducationSection() {
                       {edu.highlights.map((h, i) => (
                         <li
                           key={i}
-                          className="text-muted-foreground flex items-start text-sm leading-relaxed"
+                          className="flex items-start text-sm leading-relaxed text-muted-foreground"
                         >
                           <span className="mr-2 mt-1 text-primary">•</span>
                           {h}

--- a/components/ExperienceSection/index.tsx
+++ b/components/ExperienceSection/index.tsx
@@ -6,7 +6,7 @@ import { experiences, itemVariants } from "@/constants";
 export function ExperienceSection() {
   // Render plain-text description as a paragraph (no HTML injection)
   const renderDescription = (text: string) => (
-    <p className="text-muted-foreground mb-3 leading-relaxed">{text}</p>
+    <p className="mb-3 leading-relaxed text-muted-foreground">{text}</p>
   );
 
   // Helper to determine if experience is internship
@@ -15,7 +15,7 @@ export function ExperienceSection() {
 
   return (
     <motion.div variants={itemVariants}>
-      <h3 className="text-foreground mb-8 flex items-center text-2xl font-semibold">
+      <h3 className="mb-8 flex items-center text-2xl font-semibold text-foreground">
         <BriefcaseIcon className="mr-3 h-7 w-7 text-primary" />
         Professional Experience
       </h3>
@@ -108,7 +108,7 @@ export function ExperienceSection() {
                         {exp.highlights.map((h, i) => (
                           <p
                             key={i}
-                            className="text-muted-foreground mb-2 flex items-start text-sm"
+                            className="mb-2 flex items-start text-sm text-muted-foreground"
                           >
                             <span className="mr-2 mt-1 text-primary">•</span>
                             {h}

--- a/components/FAQSection.tsx
+++ b/components/FAQSection.tsx
@@ -10,14 +10,21 @@ interface Props {
 // Google requires visible Q&A text matching the schema or it strips the
 // rich-result eligibility — JSON-LD-only FAQ violates the policy.
 // Server-rendered for SEO; uses native <details> for zero-JS expand/collapse.
-export function FAQSection({ title = "Frequently asked questions", description, items }: Props) {
+export function FAQSection({
+  title = "Frequently asked questions",
+  description,
+  items,
+}: Props) {
   return (
     <section
       className="container mx-auto px-4 py-16"
       aria-labelledby="faq-heading"
     >
       <div className="mx-auto max-w-3xl">
-        <h2 id="faq-heading" className="text-3xl font-bold tracking-tight sm:text-4xl">
+        <h2
+          id="faq-heading"
+          className="text-3xl font-bold tracking-tight sm:text-4xl"
+        >
           {title}
         </h2>
         {description ? (
@@ -27,11 +34,7 @@ export function FAQSection({ title = "Frequently asked questions", description, 
         ) : null}
         <div className="mt-8 divide-y divide-border rounded-2xl border bg-card/50">
           {items.map((item, idx) => (
-            <details
-              key={item.question}
-              className="group p-6"
-              open={idx === 0}
-            >
+            <details key={item.question} className="group p-6" open={idx === 0}>
               <summary className="flex cursor-pointer list-none items-center justify-between text-base font-semibold text-foreground sm:text-lg [&::-webkit-details-marker]:hidden">
                 <span>{item.question}</span>
                 <span

--- a/components/HobbiesSection/index.tsx
+++ b/components/HobbiesSection/index.tsx
@@ -31,7 +31,7 @@ export function HobbiesSection() {
 
   return (
     <motion.div variants={itemVariants}>
-      <h3 className="text-foreground mb-6 flex items-center text-2xl font-semibold">
+      <h3 className="mb-6 flex items-center text-2xl font-semibold text-foreground">
         <HeartIcon className="mr-2 h-6 w-6 text-primary" />
         Hobbies
       </h3>
@@ -42,7 +42,7 @@ export function HobbiesSection() {
               <div className="flex items-center space-x-4">
                 {hobby.icon}
                 <div>
-                  <h4 className="text-foreground text-lg font-semibold">
+                  <h4 className="text-lg font-semibold text-foreground">
                     {hobby.title}
                   </h4>
                   <p className="text-muted-foreground">{hobby.description}</p>

--- a/components/SkillsSection/index.tsx
+++ b/components/SkillsSection/index.tsx
@@ -56,7 +56,7 @@ export default function SkillsSection() {
 
   return (
     <motion.div variants={itemVariants}>
-      <h3 className="text-foreground mb-6 flex items-center text-2xl font-semibold">
+      <h3 className="mb-6 flex items-center text-2xl font-semibold text-foreground">
         <CodeIcon className="mr-2 h-6 w-6 text-primary" />
         Skills
       </h3>
@@ -64,7 +64,7 @@ export default function SkillsSection() {
         {skills.map((skillCategory, index) => (
           <Card key={index} className="bg-background">
             <CardContent className="p-4">
-              <h4 className="text-foreground mb-4 text-lg font-semibold">
+              <h4 className="mb-4 text-lg font-semibold text-foreground">
                 {skillCategory.category}
               </h4>
               <div className="flex flex-wrap gap-2">
@@ -72,7 +72,7 @@ export default function SkillsSection() {
                   <motion.span
                     key={skillIndex}
                     whileHover={{ scale: 1.05 }}
-                    className="text-muted-foreground rounded-full border border-border bg-muted px-3 py-1 transition-colors duration-200 hover:bg-primary/10 hover:text-primary"
+                    className="rounded-full border border-border bg-muted px-3 py-1 text-muted-foreground transition-colors duration-200 hover:bg-primary/10 hover:text-primary"
                   >
                     {skill.name}
                   </motion.span>

--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -32,7 +32,7 @@ export function BlogCard({
   return (
     <div className="transition-transform duration-500 ease-out will-change-transform">
       <Link href={`/blog/${slug}`}>
-        <Card className="bg-background overflow-hidden transition-shadow duration-300 hover:shadow-lg">
+        <Card className="overflow-hidden bg-background transition-shadow duration-300 hover:shadow-lg">
           <div className="relative h-48">
             <Image
               src={image}
@@ -56,14 +56,14 @@ export function BlogCard({
               <span className="text-foreground">{author.name}</span>
             </div>
 
-            <h3 className="text-foreground mb-2 text-xl font-semibold">
+            <h3 className="mb-2 text-xl font-semibold text-foreground">
               {title}
             </h3>
-            <p className="text-muted-foreground mb-4 line-clamp-2">
+            <p className="mb-4 line-clamp-2 text-muted-foreground">
               {description}
             </p>
 
-            <div className="text-muted-foreground mb-4 flex items-center gap-4">
+            <div className="mb-4 flex items-center gap-4 text-muted-foreground">
               <div className="flex items-center gap-1">
                 <CalendarIcon className="h-4 w-4" />
                 <span className="text-sm">

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -29,7 +29,7 @@ export function ProjectCard({
 }: ProjectCardProps) {
   return (
     <div className="transition-transform duration-500 ease-out will-change-transform">
-      <Card className="bg-background overflow-hidden transition-shadow duration-300 hover:shadow-lg">
+      <Card className="overflow-hidden bg-background transition-shadow duration-300 hover:shadow-lg">
         <div className="relative h-48">
           <Image
             src={image}
@@ -41,10 +41,10 @@ export function ProjectCard({
           />
         </div>
         <CardContent className="p-6">
-          <h3 className="text-foreground mb-2 text-xl font-semibold">
+          <h3 className="mb-2 text-xl font-semibold text-foreground">
             {title}
           </h3>
-          <p className="text-muted-foreground mb-4">{description}</p>
+          <p className="mb-4 text-muted-foreground">{description}</p>
 
           <div className="mb-4 flex flex-wrap gap-2">
             {tags.map((tag, index) => (

--- a/content/blog/building-inventory-engine-never-oversells-concurrency.mdx
+++ b/content/blog/building-inventory-engine-never-oversells-concurrency.mdx
@@ -32,12 +32,24 @@ seoKeywords:
 ---
 
 <div class="tldr">
-<strong>TL;DR:</strong> Overselling is a read-then-write race. I built Holdfast, a reservation engine that prevents it three ways (atomic conditional update, pessimistic <code>FOR UPDATE</code>, optimistic version CAS), keeps multi-item baskets deadlock-free by locking SKUs in a fixed order, makes placement idempotent with a unique key, shards hot SKUs to beat single-row contention, and proves it all with a chaos test that kills transactions mid-flight. Live demo + repo at the end.
+  <strong>TL;DR:</strong> Overselling is a read-then-write race. I built
+  Holdfast, a reservation engine that prevents it three ways (atomic conditional
+  update, pessimistic <code>FOR UPDATE</code>, optimistic version CAS), keeps
+  multi-item baskets deadlock-free by locking SKUs in a fixed order, makes
+  placement idempotent with a unique key, shards hot SKUs to beat single-row
+  contention, and proves it all with a chaos test that kills transactions
+  mid-flight. Live demo + repo at the end.
 </div>
 
 <h2>Why overselling is harder than it looks</h2>
 
-<p>Hello everyone! I'm <strong>Shailesh Chaudhari</strong>, a backend engineer. I kept seeing the same bug in inventory code: under real concurrency, two buyers both get the "last" unit. So I built <strong>Holdfast</strong> — a small, focused reservation engine whose entire job is to <em>never oversell</em>, and to prove it.</p>
+<p>
+  Hello everyone! I'm <strong>Shailesh Chaudhari</strong>, a backend engineer. I
+  kept seeing the same bug in inventory code: under real concurrency, two buyers
+  both get the "last" unit. So I built <strong>Holdfast</strong> — a small,
+  focused reservation engine whose entire job is to <em>never oversell</em>, and
+  to prove it.
+</p>
 
 <p>The naive version looks innocent:</p>
 
@@ -48,67 +60,188 @@ if (item.available >= qty) {
 }
 </code></pre>
 
-<p>With one user, fine. With 500 users hitting it at once, it's broken. Two requests both <code>SELECT</code> "1 available", both pass the <code>if</code>, both <code>UPDATE</code>, and now you've sold 2 units of 1. The check and the write are two separate steps, and anything can happen between them. This is a classic <strong>read-then-write race</strong>, and it's the core correctness problem in quick-commerce, ticketing, and flash sales.</p>
+<p>
+  With one user, fine. With 500 users hitting it at once, it's broken. Two
+  requests both <code>SELECT</code> "1 available", both pass the <code>if</code>
+  , both <code>UPDATE</code>, and now you've sold 2 units of 1. The check and
+  the write are two separate steps, and anything can happen between them. This
+  is a classic <strong>read-then-write race</strong>, and it's the core
+  correctness problem in quick-commerce, ticketing, and flash sales.
+</p>
 
 <h2>Strategy 1 — Atomic conditional update (the default)</h2>
 
-<p>The fix is to make the check and the decrement a single atomic statement, so the database does the guarding:</p>
+<p>
+  The fix is to make the check and the decrement a single atomic statement, so
+  the database does the guarding:
+</p>
 
-<pre><code>UPDATE inventory
-SET available = available - $qty
-WHERE sku = $1 AND available &gt;= $qty;   -- 0 rows changed = not enough stock
-</code></pre>
+<pre>
+  <code>
+    UPDATE inventory SET available = available - $qty WHERE sku = $1 AND
+    available &gt;= $qty; -- 0 rows changed = not enough stock
+  </code>
+</pre>
 
-<p>The <code>WHERE available &gt;= $qty</code> clause <em>is</em> the guard. There's no separate read, no window for a race. If the row count is 0, there wasn't enough — return out-of-stock. I also add a database <code>CHECK (available &gt;= 0)</code> as a backstop, so even a bug aborts the transaction instead of going negative.</p>
+<p>
+  The <code>WHERE available &gt;= $qty</code> clause <em>is</em> the guard.
+  There's no separate read, no window for a race. If the row count is 0, there
+  wasn't enough — return out-of-stock. I also add a database{" "}
+  <code>CHECK (available &gt;= 0)</code> as a backstop, so even a bug aborts the
+  transaction instead of going negative.
+</p>
 
-<p>This is the default in Holdfast: one statement, no application-side read, no lock held open. It's simple and it's correct.</p>
+<p>
+  This is the default in Holdfast: one statement, no application-side read, no
+  lock held open. It's simple and it's correct.
+</p>
 
 <h2>Strategy 2 &amp; 3 — when you need locking or versioning</h2>
 
-<p>The atomic update handles a single quantity column. But sometimes you need to read more state, decide, and write back. Two more strategies cover that:</p>
+<p>
+  The atomic update handles a single quantity column. But sometimes you need to
+  read more state, decide, and write back. Two more strategies cover that:
+</p>
 
 <ul>
-<li><strong>Pessimistic (<code>SELECT … FOR UPDATE</code>):</strong> lock the row, then decrement. Other transactions wait. Simple, and it serializes the hot row cleanly.</li>
-<li><strong>Optimistic (version CAS):</strong> read a <code>version</code> column, then <code>UPDATE … WHERE version = $v</code>. If someone else changed it first, 0 rows match and you retry. No locks held; great when conflicts are <em>rare</em>.</li>
+  <li>
+    <strong>
+      Pessimistic (<code>SELECT … FOR UPDATE</code>):
+    </strong>{" "}
+    lock the row, then decrement. Other transactions wait. Simple, and it
+    serializes the hot row cleanly.
+  </li>
+  <li>
+    <strong>Optimistic (version CAS):</strong> read a <code>version</code>{" "}
+    column, then <code>UPDATE … WHERE version = $v</code>. If someone else
+    changed it first, 0 rows match and you retry. No locks held; great when
+    conflicts are <em>rare</em>.
+  </li>
 </ul>
 
-<p>Which is best? I didn't guess — I benchmarked them against real PostgreSQL. On a single hot row (all buyers, one SKU), pessimistic and atomic win (~3,600-3,650 reservations/sec) because they serialize efficiently; optimistic is slowest there because it averages two attempts per success (it retries the lost races). Optimistic's advantage is the <em>opposite</em> workload — contention spread across many rows, where conflicts are rare and you avoid holding locks. <strong>The lesson: pick the strategy for your contention shape, and measure.</strong></p>
+<p>
+  Which is best? I didn't guess — I benchmarked them against real PostgreSQL. On
+  a single hot row (all buyers, one SKU), pessimistic and atomic win
+  (~3,600-3,650 reservations/sec) because they serialize efficiently; optimistic
+  is slowest there because it averages two attempts per success (it retries the
+  lost races). Optimistic's advantage is the <em>opposite</em> workload —
+  contention spread across many rows, where conflicts are rare and you avoid
+  holding locks.{" "}
+  <strong>
+    The lesson: pick the strategy for your contention shape, and measure.
+  </strong>
+</p>
 
 <h2>The hard part: multi-item baskets without deadlocks</h2>
 
-<p>A real cart reserves several SKUs at once, all-or-nothing. The trap is <strong>deadlock</strong>: cart A locks milk then waits for eggs; cart B locks eggs then waits for milk. Each holds one and waits for the other forever, and the database has to abort one.</p>
+<p>
+  A real cart reserves several SKUs at once, all-or-nothing. The trap is{" "}
+  <strong>deadlock</strong>: cart A locks milk then waits for eggs; cart B locks
+  eggs then waits for milk. Each holds one and waits for the other forever, and
+  the database has to abort one.
+</p>
 
-<p>The fix is elegant: <strong>always acquire rows in one fixed global order — sorted by SKU.</strong> If every basket grabs shared SKUs in the same sequence, no lock cycle can form. I have a test that fires 100 baskets locking the same two SKUs in opposite order and asserts <strong>zero deadlocks</strong> with a consistent ledger. Any out-of-stock line rolls the whole basket back.</p>
+<p>
+  The fix is elegant:{" "}
+  <strong>
+    always acquire rows in one fixed global order — sorted by SKU.
+  </strong>{" "}
+  If every basket grabs shared SKUs in the same sequence, no lock cycle can
+  form. I have a test that fires 100 baskets locking the same two SKUs in
+  opposite order and asserts <strong>zero deadlocks</strong> with a consistent
+  ledger. Any out-of-stock line rolls the whole basket back.
+</p>
 
 <h2>Placing an order exactly once (idempotency)</h2>
 
-<p>Networks retry. A user double-clicks. A mobile client resends on a flaky connection. Without protection, one intent becomes two reservations. Holdfast accepts an <code>Idempotency-Key</code> with each request, enforced by a <code>UNIQUE</code> constraint:</p>
+<p>
+  Networks retry. A user double-clicks. A mobile client resends on a flaky
+  connection. Without protection, one intent becomes two reservations. Holdfast
+  accepts an <code>Idempotency-Key</code> with each request, enforced by a{" "}
+  <code>UNIQUE</code> constraint:
+</p>
 
-<pre><code>orders (id, idempotency_key UNIQUE, ...)
-</code></pre>
+<pre>
+  <code>orders (id, idempotency_key UNIQUE, ...)</code>
+</pre>
 
-<p>The reservation runs in one transaction. If a retry arrives with the same key, the insert collides with the unique constraint, the whole transaction (including the decrement) rolls back, and we return the original order. Proven with 100 concurrent identical requests producing <strong>exactly one</strong> reservation. This is the same pattern Stripe uses for payment idempotency keys — applied to inventory.</p>
+<p>
+  The reservation runs in one transaction. If a retry arrives with the same key,
+  the insert collides with the unique constraint, the whole transaction
+  (including the decrement) rolls back, and we return the original order. Proven
+  with 100 concurrent identical requests producing <strong>exactly one</strong>{" "}
+  reservation. This is the same pattern Stripe uses for payment idempotency keys
+  — applied to inventory.
+</p>
 
 <h2>Scaling the hot SKU</h2>
 
-<p>One viral product is one inventory row, which is one lock, which is your throughput ceiling. The standard fix is to <strong>shard the stock</strong>: split a SKU's quantity across N sub-rows, decrement a random shard, and fall back through the others if one is empty. Now you have N locks instead of one. I benchmarked this in Holdfast — throughput climbed roughly 3.5× at 16 shards before plateauing on the database itself (about 49,000 reservations/sec). For extreme drops, the next step is reserving in Redis with periodic reconciliation to the database, but that's only worth the added complexity once you've proven you need it.</p>
+<p>
+  One viral product is one inventory row, which is one lock, which is your
+  throughput ceiling. The standard fix is to <strong>shard the stock</strong>:
+  split a SKU's quantity across N sub-rows, decrement a random shard, and fall
+  back through the others if one is empty. Now you have N locks instead of one.
+  I benchmarked this in Holdfast — throughput climbed roughly 3.5× at 16 shards
+  before plateauing on the database itself (about 49,000 reservations/sec). For
+  extreme drops, the next step is reserving in Redis with periodic
+  reconciliation to the database, but that's only worth the added complexity
+  once you've proven you need it.
+</p>
 
 <h2>Proving it fails closed (the chaos test)</h2>
 
-<p>Claiming "no oversell" is easy. Proving it under failure is the interesting part. Holdfast has a <strong>chaos test</strong> that kills PostgreSQL backends mid-transaction while buyers race. The guarantee that has to hold: when a transaction dies, it rolls back — no phantom stock, no partial reservation, the ledger stays consistent. The system <em>fails closed</em>: under stress it refuses orders rather than risk overselling. In quick-commerce, a refused order is a minor annoyance; an oversold one is a cancelled order and a lost customer.</p>
+<p>
+  Claiming "no oversell" is easy. Proving it under failure is the interesting
+  part. Holdfast has a <strong>chaos test</strong> that kills PostgreSQL
+  backends mid-transaction while buyers race. The guarantee that has to hold:
+  when a transaction dies, it rolls back — no phantom stock, no partial
+  reservation, the ledger stays consistent. The system <em>fails closed</em>:
+  under stress it refuses orders rather than risk overselling. In
+  quick-commerce, a refused order is a minor annoyance; an oversold one is a
+  cancelled order and a lost customer.
+</p>
 
 <h2>Stack &amp; honest notes</h2>
 
-<p>Holdfast is TypeScript on Fastify, with a deliberate hybrid data layer: <strong>Drizzle ORM</strong> owns the schema, migrations, and ordinary reads (type-safe and model-driven), while the reservation hot path is <strong>raw SQL</strong> — because the whole point is the explicit locking, which an ORM's query builder hides, and interactive ORM transactions get flaky under heavy concurrency. "ORM for productivity, raw SQL where correctness and performance demand it" is how production teams actually work. There's Prometheus metrics, a Docker deploy that self-seeds, and 18 tests against real PostgreSQL.</p>
+<p>
+  Holdfast is TypeScript on Fastify, with a deliberate hybrid data layer:{" "}
+  <strong>Drizzle ORM</strong> owns the schema, migrations, and ordinary reads
+  (type-safe and model-driven), while the reservation hot path is{" "}
+  <strong>raw SQL</strong> — because the whole point is the explicit locking,
+  which an ORM's query builder hides, and interactive ORM transactions get flaky
+  under heavy concurrency. "ORM for productivity, raw SQL where correctness and
+  performance demand it" is how production teams actually work. There's
+  Prometheus metrics, a Docker deploy that self-seeds, and 18 tests against real
+  PostgreSQL.
+</p>
 
-<p>Two honest caveats: the throughput numbers are a single-machine local benchmark — treat them as relative, not absolute. And Holdfast is the reservation <em>core</em>, not a full store; payments live in separate demos by design. Every claim here is backed by a test or a benchmark you can run yourself.</p>
+<p>
+  Two honest caveats: the throughput numbers are a single-machine local
+  benchmark — treat them as relative, not absolute. And Holdfast is the
+  reservation <em>core</em>, not a full store; payments live in separate demos
+  by design. Every claim here is backed by a test or a benchmark you can run
+  yourself.
+</p>
 
 <h2>Try it</h2>
 
-<p>The engine is live and open source. Fire concurrent requests at it and watch it hold the line:</p>
+<p>
+  The engine is live and open source. Fire concurrent requests at it and watch
+  it hold the line:
+</p>
 
 <ul>
-<li><strong>Source:</strong> <a href="https://github.com/Shailesh93602/holdfast">github.com/Shailesh93602/holdfast</a></li>
+  <li>
+    <strong>Source:</strong>{" "}
+    <a href="https://github.com/Shailesh93602/holdfast">
+      github.com/Shailesh93602/holdfast
+    </a>
+  </li>
 </ul>
 
-<p>If you're building anything that touches stock, money, or limited capacity under concurrency, these patterns — atomic guards, fixed lock ordering, idempotency keys, and failing closed — are the ones that keep you out of trouble. Thanks for reading!</p>
+<p>
+  If you're building anything that touches stock, money, or limited capacity
+  under concurrency, these patterns — atomic guards, fixed lock ordering,
+  idempotency keys, and failing closed — are the ones that keep you out of
+  trouble. Thanks for reading!
+</p>

--- a/content/blog/idempotency-keys-retry-safe-payment-apis.mdx
+++ b/content/blog/idempotency-keys-retry-safe-payment-apis.mdx
@@ -33,12 +33,24 @@ seoKeywords:
 ---
 
 <div class="tldr">
-<strong>TL;DR:</strong> Any endpoint that moves money or creates a resource will eventually be called twice for one intent — a network retry, a double-click, a redelivered webhook. The fix is an <em>idempotency key</em>: a client-supplied id that lets the server run the operation <strong>at most once</strong> and replay the stored result on every repeat. The subtle parts are concurrency (two retries arriving at the same instant), releasing the key when the operation fails, and rejecting a key reused for a <em>different</em> request. I packaged the whole pattern into <a href="https://github.com/Shailesh93602/idempotency-kit">idempotency-kit</a>, a zero-dependency TypeScript library — this post walks through the design.
+  <strong>TL;DR:</strong> Any endpoint that moves money or creates a resource
+  will eventually be called twice for one intent — a network retry, a
+  double-click, a redelivered webhook. The fix is an <em>idempotency key</em>: a
+  client-supplied id that lets the server run the operation{" "}
+  <strong>at most once</strong> and replay the stored result on every repeat.
+  The subtle parts are concurrency (two retries arriving at the same instant),
+  releasing the key when the operation fails, and rejecting a key reused for a{" "}
+  <em>different</em> request. I packaged the whole pattern into{" "}
+  <a href="https://github.com/Shailesh93602/idempotency-kit">idempotency-kit</a>
+  , a zero-dependency TypeScript library — this post walks through the design.
 </div>
 
 <h2>The bug that hides until production traffic</h2>
 
-<p>Hello everyone! I'm <strong>Shailesh Chaudhari</strong>, a backend engineer. Here's a charge endpoint that looks completely fine:</p>
+<p>
+  Hello everyone! I'm <strong>Shailesh Chaudhari</strong>, a backend engineer.
+  Here's a charge endpoint that looks completely fine:
+</p>
 
 <pre><code>app.post("/charge", async (req, res) =&gt; {
   const charge = await psp.charge(req.body); // call the payment provider
@@ -47,43 +59,105 @@ seoKeywords:
 });
 </code></pre>
 
-<p>It works in every test. Then it ships, and a week later a customer is charged twice for one order. Nobody wrote a bug — the network did. The client sent the request, the charge went through, and the <em>response</em> got lost on the way back. The client's HTTP library, seeing no response, did the sensible thing: it retried. The server, having no memory of the first call, charged again.</p>
+<p>
+  It works in every test. Then it ships, and a week later a customer is charged
+  twice for one order. Nobody wrote a bug — the network did. The client sent the
+  request, the charge went through, and the <em>response</em> got lost on the
+  way back. The client's HTTP library, seeing no response, did the sensible
+  thing: it retried. The server, having no memory of the first call, charged
+  again.
+</p>
 
-<p>This is not an edge case you can avoid. Mobile clients retry on flaky connections. Load balancers retry on timeouts. Users double-click "Pay". Payment providers redeliver webhooks until you return a 2xx — sometimes more than once even after you do. <strong>At-least-once delivery is the default of the internet.</strong> If your write endpoint isn't safe to call twice, it's a question of <em>when</em>, not <em>if</em>.</p>
+<p>
+  This is not an edge case you can avoid. Mobile clients retry on flaky
+  connections. Load balancers retry on timeouts. Users double-click "Pay".
+  Payment providers redeliver webhooks until you return a 2xx — sometimes more
+  than once even after you do.{" "}
+  <strong>At-least-once delivery is the default of the internet.</strong> If
+  your write endpoint isn't safe to call twice, it's a question of <em>when</em>
+  , not <em>if</em>.
+</p>
 
 <h2>The idea: an idempotency key</h2>
 
-<p>An <strong>idempotency key</strong> is a unique id the client generates per intent (a UUID is fine) and sends with the request, usually as an <code>Idempotency-Key</code> header. The contract on the server is:</p>
+<p>
+  An <strong>idempotency key</strong> is a unique id the client generates per
+  intent (a UUID is fine) and sends with the request, usually as an{" "}
+  <code>Idempotency-Key</code> header. The contract on the server is:
+</p>
 
 <ul>
-<li>First time I see this key: run the operation, store the result against the key, return it.</li>
-<li>Every later time I see the same key: <strong>do not run again</strong> — return the stored result.</li>
+  <li>
+    First time I see this key: run the operation, store the result against the
+    key, return it.
+  </li>
+  <li>
+    Every later time I see the same key: <strong>do not run again</strong> —
+    return the stored result.
+  </li>
 </ul>
 
-<p>One intent, one execution, no matter how many times the request arrives. This is exactly how Stripe's <code>Idempotency-Key</code> works, and the same exactly-once idea behind the reservation engine I wrote about in <a href="/blog/building-inventory-engine-never-oversells-concurrency">Holdfast</a> — there enforced with a <code>UNIQUE</code> constraint on the order key.</p>
+<p>
+  One intent, one execution, no matter how many times the request arrives. This
+  is exactly how Stripe's <code>Idempotency-Key</code> works, and the same
+  exactly-once idea behind the reservation engine I wrote about in{" "}
+  <a href="/blog/building-inventory-engine-never-oversells-concurrency">
+    Holdfast
+  </a>{" "}
+  — there enforced with a <code>UNIQUE</code> constraint on the order key.
+</p>
 
-<p>The naive implementation is a check-then-act, and it has the same flaw as the double charge:</p>
+<p>
+  The naive implementation is a check-then-act, and it has the same flaw as the
+  double charge:
+</p>
 
-<pre><code>// DON'T do this — it has a race
-const seen = await store.get(key);
-if (seen) return seen.result;
-const result = await run();
-await store.save(key, result);
-</code></pre>
+<pre>
+  <code>
+    // DON'T do this — it has a race const seen = await store.get(key); if
+    (seen) return seen.result; const result = await run(); await store.save(key,
+    result);
+  </code>
+</pre>
 
-<p>Two retries arriving at the same instant both <code>get</code> nothing, both pass the <code>if</code>, both <code>run()</code>. We're back to a double charge — now with extra steps. The check and the write have to be a single atomic operation. That one realization shapes the entire design.</p>
+<p>
+  Two retries arriving at the same instant both <code>get</code> nothing, both
+  pass the <code>if</code>, both <code>run()</code>. We're back to a double
+  charge — now with extra steps. The check and the write have to be a single
+  atomic operation. That one realization shapes the entire design.
+</p>
 
 <h2>The protocol: claim → run → complete</h2>
 
-<p>The pattern that actually holds under concurrency splits the work into three store operations, where <strong>claim</strong> is the only one that must be atomic:</p>
+<p>
+  The pattern that actually holds under concurrency splits the work into three
+  store operations, where <strong>claim</strong> is the only one that must be
+  atomic:
+</p>
 
 <ul>
-<li><strong>claim(key):</strong> atomically insert an <code>in_progress</code> record <em>if the key is free</em>. Returns "you own it" to exactly one caller; everyone else gets the existing record. In Redis this is a <code>SET key value NX</code>; in SQL it's an <code>INSERT</code> that trips a unique constraint.</li>
-<li><strong>complete(key, result):</strong> the owner runs the operation, then stores the serialized result and flips the record to <code>completed</code>.</li>
-<li><strong>release(key):</strong> if the operation throws, drop the <code>in_progress</code> claim so a later retry can try again.</li>
+  <li>
+    <strong>claim(key):</strong> atomically insert an <code>in_progress</code>{" "}
+    record <em>if the key is free</em>. Returns "you own it" to exactly one
+    caller; everyone else gets the existing record. In Redis this is a{" "}
+    <code>SET key value NX</code>; in SQL it's an <code>INSERT</code> that trips
+    a unique constraint.
+  </li>
+  <li>
+    <strong>complete(key, result):</strong> the owner runs the operation, then
+    stores the serialized result and flips the record to <code>completed</code>.
+  </li>
+  <li>
+    <strong>release(key):</strong> if the operation throws, drop the{" "}
+    <code>in_progress</code> claim so a later retry can try again.
+  </li>
 </ul>
 
-<p>Here is the core of <a href="https://github.com/Shailesh93602/idempotency-kit">idempotency-kit</a>, lightly trimmed:</p>
+<p>
+  Here is the core of{" "}
+  <a href="https://github.com/Shailesh93602/idempotency-kit">idempotency-kit</a>
+  , lightly trimmed:
+</p>
 
 <pre><code>const existing = await store.claim(key, now());
 
@@ -105,33 +179,81 @@ if (existing.status === "completed") {
 // else: someone else holds an in_progress claim (see below)
 </code></pre>
 
-<p>Because <code>claim</code> is atomic, two simultaneous retries can't both win. One gets <code>null</code> and runs; the other gets the <code>in_progress</code> record and knows not to. The race is gone — not because the application code is clever, but because the one operation that must be atomic was pushed down to where atomicity is cheap and guaranteed.</p>
+<p>
+  Because <code>claim</code> is atomic, two simultaneous retries can't both win.
+  One gets <code>null</code> and runs; the other gets the{" "}
+  <code>in_progress</code> record and knows not to. The race is gone — not
+  because the application code is clever, but because the one operation that
+  must be atomic was pushed down to where atomicity is cheap and guaranteed.
+</p>
 
 <h2>What about the retry that arrives mid-flight?</h2>
 
-<p>The interesting case is the loser of the claim: a second request whose key is held by an <code>in_progress</code> claim that hasn't finished yet. There's no stored result to replay. You have two honest options, and the right one depends on the caller:</p>
+<p>
+  The interesting case is the loser of the claim: a second request whose key is
+  held by an <code>in_progress</code> claim that hasn't finished yet. There's no
+  stored result to replay. You have two honest options, and the right one
+  depends on the caller:
+</p>
 
 <ul>
-<li><strong>Fail fast.</strong> Return a 409 Conflict ("a request with this key is already in progress"). The client can retry later. This is the safe default and what Stripe does — it never blocks a connection waiting.</li>
-<li><strong>Wait and replay.</strong> Poll briefly for the winner to finish, then return its result. Nicer for the caller, but it holds a connection open, so it needs a tight bound.</li>
+  <li>
+    <strong>Fail fast.</strong> Return a 409 Conflict ("a request with this key
+    is already in progress"). The client can retry later. This is the safe
+    default and what Stripe does — it never blocks a connection waiting.
+  </li>
+  <li>
+    <strong>Wait and replay.</strong> Poll briefly for the winner to finish,
+    then return its result. Nicer for the caller, but it holds a connection
+    open, so it needs a tight bound.
+  </li>
 </ul>
 
-<p>The library makes this a one-line choice — default is fail-fast; opt into waiting with <code>waitRetries</code>:</p>
+<p>
+  The library makes this a one-line choice — default is fail-fast; opt into
+  waiting with <code>waitRetries</code>:
+</p>
 
 <pre><code>await withIdempotency(key, fn, { store, waitRetries: 10, waitIntervalMs: 100 });
 </code></pre>
 
 <h2>The detail everyone forgets: releasing on failure</h2>
 
-<p>Picture this: the operation fails — the payment provider times out, the database is briefly down. If you <em>completed</em> the key anyway, or simply left the <code>in_progress</code> claim sitting there, every future retry with that key would replay a failure or be told "already in progress" forever. The user's legitimate retry can never succeed. The key is <strong>poisoned</strong>.</p>
+<p>
+  Picture this: the operation fails — the payment provider times out, the
+  database is briefly down. If you <em>completed</em> the key anyway, or simply
+  left the <code>in_progress</code> claim sitting there, every future retry with
+  that key would replay a failure or be told "already in progress" forever. The
+  user's legitimate retry can never succeed. The key is{" "}
+  <strong>poisoned</strong>.
+</p>
 
-<p>That's why the <code>catch</code> block above calls <code>release</code>. A <em>transient</em> failure must free the key so the next attempt gets a clean shot. This is the difference between "idempotent" and "idempotent and actually usable". It's also the line most homegrown implementations miss, because it only bites when something downstream is already broken — exactly when you most need retries to work.</p>
+<p>
+  That's why the <code>catch</code> block above calls <code>release</code>. A{" "}
+  <em>transient</em> failure must free the key so the next attempt gets a clean
+  shot. This is the difference between "idempotent" and "idempotent and actually
+  usable". It's also the line most homegrown implementations miss, because it
+  only bites when something downstream is already broken — exactly when you most
+  need retries to work.
+</p>
 
 <h2>The guard Stripe ships and most clones don't: fingerprint mismatch</h2>
 
-<p>Here's a nastier failure. A client reuses an idempotency key for a <em>different</em> request — maybe it generates keys too coarsely, maybe it's a plain bug. Request one: charge $10. Request two, same key: charge $99. A naive cache happily replays the $10 result for the $99 request. No error, no double charge — just a <strong>silently wrong answer</strong>, which is worse, because nobody notices until reconciliation.</p>
+<p>
+  Here's a nastier failure. A client reuses an idempotency key for a{" "}
+  <em>different</em> request — maybe it generates keys too coarsely, maybe it's
+  a plain bug. Request one: charge $10. Request two, same key: charge $99. A
+  naive cache happily replays the $10 result for the $99 request. No error, no
+  double charge — just a <strong>silently wrong answer</strong>, which is worse,
+  because nobody notices until reconciliation.
+</p>
 
-<p>Stripe guards against this: reuse a key with different parameters and you get a <code>400</code>, not a replay. To do the same, store a <strong>fingerprint</strong> of the request payload alongside the key, and compare on every hit:</p>
+<p>
+  Stripe guards against this: reuse a key with different parameters and you get
+  a <code>400</code>, not a replay. To do the same, store a{" "}
+  <strong>fingerprint</strong> of the request payload alongside the key, and
+  compare on every hit:
+</p>
 
 <pre><code>await withIdempotency(key, () =&gt; psp.charge(req.body), {
   store,
@@ -143,17 +265,46 @@ if (existing.status === "completed") {
 
 <p>The fingerprint has to be <strong>canonical</strong>: <code>{ amount, currency }</code> and <code>{ currency, amount }</code> are the same request, so key order can't change the hash. In the library I sort object keys recursively before hashing, recurse into nested objects and arrays, and deliberately avoid <code>node:crypto</code> so the same function runs on the edge, Deno, or a browser. It's a guard against accidental reuse, not an adversary — a fast non-cryptographic hash is the right tool.</p>
 
-<p>One subtlety I only caught because a test caught it: the fingerprint must survive the <code>in_progress → completed</code> transition. My first version stored it on <code>claim</code> and then <em>overwrote</em> the record on <code>complete</code>, dropping it — so the mismatch check silently stopped working after the first call finished. The test that reused a key with a different payload <em>after</em> completion went red, and that's the whole point of writing the test that asserts the outcome rather than the one that asserts "it returned something".</p>
+<p>
+  One subtlety I only caught because a test caught it: the fingerprint must
+  survive the <code>in_progress → completed</code> transition. My first version
+  stored it on <code>claim</code> and then <em>overwrote</em> the record on{" "}
+  <code>complete</code>, dropping it — so the mismatch check silently stopped
+  working after the first call finished. The test that reused a key with a
+  different payload <em>after</em> completion went red, and that's the whole
+  point of writing the test that asserts the outcome rather than the one that
+  asserts "it returned something".
+</p>
 
 <h2>Keys don't live forever (TTL)</h2>
 
-<p>Stored results can't accumulate without bound. Stripe expires idempotency keys after 24 hours, and that's a sensible default: long enough to cover any realistic retry storm, short enough that the store doesn't grow forever. After the TTL the key is free again. The trade-off is real — a retry that arrives <em>after</em> expiry will execute as a fresh request — so the window should comfortably exceed your longest retry path (including a payment provider's webhook redelivery schedule, which can span hours).</p>
+<p>
+  Stored results can't accumulate without bound. Stripe expires idempotency keys
+  after 24 hours, and that's a sensible default: long enough to cover any
+  realistic retry storm, short enough that the store doesn't grow forever. After
+  the TTL the key is free again. The trade-off is real — a retry that arrives{" "}
+  <em>after</em> expiry will execute as a fresh request — so the window should
+  comfortably exceed your longest retry path (including a payment provider's
+  webhook redelivery schedule, which can span hours).
+</p>
 
 <h2>Where the atomicity actually lives</h2>
 
-<p>The thing I want to leave you with is an architecture point, not a payments point. Notice that none of the logic above is hard <em>except</em> the atomic <code>claim</code>. So that's the only thing the storage layer is responsible for. Everything else — the fail-fast-vs-wait policy, serialization, the fingerprint comparison, releasing on error — is plain, testable application code that doesn't care whether it's running over an in-memory map, Redis, or Postgres.</p>
+<p>
+  The thing I want to leave you with is an architecture point, not a payments
+  point. Notice that none of the logic above is hard <em>except</em> the atomic{" "}
+  <code>claim</code>. So that's the only thing the storage layer is responsible
+  for. Everything else — the fail-fast-vs-wait policy, serialization, the
+  fingerprint comparison, releasing on error — is plain, testable application
+  code that doesn't care whether it's running over an in-memory map, Redis, or
+  Postgres.
+</p>
 
-<p>That's why the library defines a tiny store interface and ships an in-memory implementation for tests, and why moving to a distributed setup means writing one small adapter — a <code>SET NX</code> for the claim, nothing else changes:</p>
+<p>
+  That's why the library defines a tiny store interface and ships an in-memory
+  implementation for tests, and why moving to a distributed setup means writing
+  one small adapter — a <code>SET NX</code> for the claim, nothing else changes:
+</p>
 
 <pre><code>interface IdempotencyStore {
   claim(key, now, fingerprint?): Promise&lt;Record | null&gt;; // atomic insert-if-absent
@@ -163,15 +314,40 @@ if (existing.status === "completed") {
 }
 </code></pre>
 
-<p>"Push the one operation that must be atomic down to the layer that can guarantee it, and keep everything above it boring" is the same principle behind Holdfast's reservation path. Get that boundary right and the concurrency stops being scary.</p>
+<p>
+  "Push the one operation that must be atomic down to the layer that can
+  guarantee it, and keep everything above it boring" is the same principle
+  behind Holdfast's reservation path. Get that boundary right and the
+  concurrency stops being scary.
+</p>
 
 <h2>Try it</h2>
 
-<p>The library is open source, fully typed, zero-dependency, and offline-testable (the clock is injectable, so tests are deterministic — no <code>sleep</code>, no real network):</p>
+<p>
+  The library is open source, fully typed, zero-dependency, and offline-testable
+  (the clock is injectable, so tests are deterministic — no <code>sleep</code>,
+  no real network):
+</p>
 
 <ul>
-<li><strong>Source:</strong> <a href="https://github.com/Shailesh93602/idempotency-kit">github.com/Shailesh93602/idempotency-kit</a></li>
-<li><strong>Related read:</strong> <a href="/blog/building-inventory-engine-never-oversells-concurrency">Building an inventory engine that never oversells under concurrency</a></li>
+  <li>
+    <strong>Source:</strong>{" "}
+    <a href="https://github.com/Shailesh93602/idempotency-kit">
+      github.com/Shailesh93602/idempotency-kit
+    </a>
+  </li>
+  <li>
+    <strong>Related read:</strong>{" "}
+    <a href="/blog/building-inventory-engine-never-oversells-concurrency">
+      Building an inventory engine that never oversells under concurrency
+    </a>
+  </li>
 </ul>
 
-<p>If you're building anything that charges a card, sends a message, or creates a resource on a <code>POST</code>, make it idempotent before it ships — not after the first double-charge ticket. Claim atomically, replay on repeat, release on failure, reject mismatched reuse, and expire on a TTL. Thanks for reading!</p>
+<p>
+  If you're building anything that charges a card, sends a message, or creates a
+  resource on a <code>POST</code>, make it idempotent before it ships — not
+  after the first double-charge ticket. Claim atomically, replay on repeat,
+  release on failure, reject mismatched reuse, and expire on a TTL. Thanks for
+  reading!
+</p>

--- a/content/blog/production-rag-that-says-i-dont-know.mdx
+++ b/content/blog/production-rag-that-says-i-dont-know.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Production RAG That Says \"I Don't Know\" Instead of Hallucinating"
+title: 'Production RAG That Says "I Don''t Know" Instead of Hallucinating'
 subtitle: "The boring, reliable parts most RAG demos skip — a refusal guardrail, idempotent ingestion, retries, and an eval harness — built into Grounded"
 description: "Most RAG demos look great until real users hit them, then they hallucinate, re-embed everything on every deploy, and you have no way to tell if a prompt change made things worse. Here's how I built Grounded to do the reliable parts right: a retrieval-score guardrail that refuses to answer, content-hash idempotent ingestion, retry-with-backoff, cited answers, and a CI eval harness."
 image: "/Images/portfolio1.png"
@@ -31,18 +31,41 @@ seoKeywords:
 ---
 
 <div class="tldr">
-<strong>TL;DR:</strong> A RAG demo proves it <em>can</em> answer. Production is about what it does when it <em>can't</em> — and whether you'd notice if it got worse. Grounded does four things demos skip: a retrieval-score guardrail that refuses instead of guessing, content-hash idempotent ingestion (stop paying to re-embed), retry-with-backoff that fails fast on 4xx, and a CI eval harness. It runs offline with no API key. Repo at the end.
+  <strong>TL;DR:</strong> A RAG demo proves it <em>can</em> answer. Production
+  is about what it does when it <em>can't</em> — and whether you'd notice if it
+  got worse. Grounded does four things demos skip: a retrieval-score guardrail
+  that refuses instead of guessing, content-hash idempotent ingestion (stop
+  paying to re-embed), retry-with-backoff that fails fast on 4xx, and a CI eval
+  harness. It runs offline with no API key. Repo at the end.
 </div>
 
 <h2>Why most RAG breaks in production</h2>
 
-<p>Hello everyone! I'm <strong>Shailesh Chaudhari</strong>, a backend engineer. Retrieval-augmented generation is easy to demo and hard to ship. The demo answers your three test questions beautifully. Then real users arrive and it confidently makes things up, your embedding bill balloons because every deploy re-embeds the whole corpus, and a prompt tweak silently makes retrieval worse with no alarm. I built <strong>Grounded</strong> — a small, readable RAG starter — to get the boring, reliable parts right. Here are the four that matter most.</p>
+<p>
+  Hello everyone! I'm <strong>Shailesh Chaudhari</strong>, a backend engineer.
+  Retrieval-augmented generation is easy to demo and hard to ship. The demo
+  answers your three test questions beautifully. Then real users arrive and it
+  confidently makes things up, your embedding bill balloons because every deploy
+  re-embeds the whole corpus, and a prompt tweak silently makes retrieval worse
+  with no alarm. I built <strong>Grounded</strong> — a small, readable RAG
+  starter — to get the boring, reliable parts right. Here are the four that
+  matter most.
+</p>
 
 <h2>1. The "I don't know" guardrail</h2>
 
-<p>The single most important reliability feature is knowing when <em>not</em> to answer. The naive pipeline retrieves some chunks and stuffs them into the prompt no matter how irrelevant they are — so an off-topic question gets a confident, wrong answer built from unrelated context.</p>
+<p>
+  The single most important reliability feature is knowing when <em>not</em> to
+  answer. The naive pipeline retrieves some chunks and stuffs them into the
+  prompt no matter how irrelevant they are — so an off-topic question gets a
+  confident, wrong answer built from unrelated context.
+</p>
 
-<p>Grounded gates on the retrieval score. In the <code>ask</code> pipeline: embed the question, query the store for the top-k chunks, and look at the best similarity score:</p>
+<p>
+  Grounded gates on the retrieval score. In the <code>ask</code> pipeline: embed
+  the question, query the store for the top-k chunks, and look at the best
+  similarity score:
+</p>
 
 <pre><code>const top = retrieved[0];
 if (!top || top.score &lt; minScore) {
@@ -51,23 +74,47 @@ if (!top || top.score &lt; minScore) {
 // only now do we call the LLM
 </code></pre>
 
-<p>If nothing clears the threshold, it returns a fixed refusal and <strong>never even calls the model</strong>. The system prompt also says "answer only from context, say you don't know otherwise" — but I don't rely on the prompt alone. The retrieval-score gate is the hard guarantee; the prompt is defense-in-depth. A model can be talked out of a prompt instruction; it can't answer from context it was never given.</p>
+<p>
+  If nothing clears the threshold, it returns a fixed refusal and{" "}
+  <strong>never even calls the model</strong>. The system prompt also says
+  "answer only from context, say you don't know otherwise" — but I don't rely on
+  the prompt alone. The retrieval-score gate is the hard guarantee; the prompt
+  is defense-in-depth. A model can be talked out of a prompt instruction; it
+  can't answer from context it was never given.
+</p>
 
 <h2>2. Idempotent ingestion (stop re-embedding everything)</h2>
 
-<p>Embeddings cost money and time per call. Naive ingestion re-embeds the entire corpus on every run, so every deploy burns API spend re-creating vectors that didn't change. Grounded hashes each chunk's content and only embeds what's new:</p>
+<p>
+  Embeddings cost money and time per call. Naive ingestion re-embeds the entire
+  corpus on every run, so every deploy burns API spend re-creating vectors that
+  didn't change. Grounded hashes each chunk's content and only embeds what's
+  new:
+</p>
 
-<pre><code>const chunks = chunkDoc(doc);
-const existing = await store.existingHashes(doc.id);
-const fresh = chunks.filter((c) =&gt; !existing.has(c.contentHash));
-// embed only `fresh`; prune chunks that no longer exist
-</code></pre>
+<pre>
+  <code>
+    const chunks = chunkDoc(doc); const existing = await
+    store.existingHashes(doc.id); const fresh = chunks.filter((c) =&gt;
+    !existing.has(c.contentHash)); // embed only `fresh`; prune chunks that no
+    longer exist
+  </code>
+</pre>
 
-<p>Re-ingesting unchanged docs becomes a near-no-op (<code>embedded: 0</code>). Chunks that were deleted from a document get pruned. This is the same idempotency discipline you'd apply to payments or a reservation system — applied to embedding spend.</p>
+<p>
+  Re-ingesting unchanged docs becomes a near-no-op (<code>embedded: 0</code>).
+  Chunks that were deleted from a document get pruned. This is the same
+  idempotency discipline you'd apply to payments or a reservation system —
+  applied to embedding spend.
+</p>
 
 <h2>3. Resilience: retry, but fail fast on 4xx</h2>
 
-<p>LLM and embedding APIs are flaky. Grounded wraps calls in exponential backoff <em>with jitter</em>, but the important decision is <strong>what's retryable</strong>:</p>
+<p>
+  LLM and embedding APIs are flaky. Grounded wraps calls in exponential backoff{" "}
+  <em>with jitter</em>, but the important decision is{" "}
+  <strong>what's retryable</strong>:
+</p>
 
 <pre><code>function isRetryable(err) {
   if (err.code === "ECONNRESET" || err.code === "ETIMEDOUT") return true;
@@ -76,27 +123,75 @@ const fresh = chunks.filter((c) =&gt; !existing.has(c.contentHash));
 }
 </code></pre>
 
-<p>Network blips and <code>429</code>/<code>5xx</code> get retried. A <code>4xx</code> (bad request, auth failure) fails immediately — retrying a 400 just hammers the API and delays the inevitable. Jitter avoids a thundering herd of synchronized retries. This is unglamorous and it's exactly what keeps a feature up under real load.</p>
+<p>
+  Network blips and <code>429</code>/<code>5xx</code> get retried. A{" "}
+  <code>4xx</code> (bad request, auth failure) fails immediately — retrying a
+  400 just hammers the API and delays the inevitable. Jitter avoids a thundering
+  herd of synchronized retries. This is unglamorous and it's exactly what keeps
+  a feature up under real load.
+</p>
 
 <h2>4. An eval harness so you catch regressions</h2>
 
-<p>"Did my prompt change make things better or worse?" is unanswerable without measurement, and most teams ship blind. Grounded ships a labelled Q&amp;A set scored by the pipeline — checking retrieval, answer quality, and crucially the <strong>refusal cases</strong> (off-topic questions must return <code>grounded: false</code>). It runs in CI, so a change that quietly breaks retrieval fails the build instead of reaching users. This is the regression test suite for your LLM feature.</p>
+<p>
+  "Did my prompt change make things better or worse?" is unanswerable without
+  measurement, and most teams ship blind. Grounded ships a labelled Q&amp;A set
+  scored by the pipeline — checking retrieval, answer quality, and crucially the{" "}
+  <strong>refusal cases</strong> (off-topic questions must return{" "}
+  <code>grounded: false</code>). It runs in CI, so a change that quietly breaks
+  retrieval fails the build instead of reaching users. This is the regression
+  test suite for your LLM feature.
+</p>
 
 <h2>Cited answers, and an honest design choice</h2>
 
-<p>Every answer carries citations built from the chunks that were actually retrieved (source, chunk id, score, snippet) — not whatever the model typed — so there's a real audit trail. And the whole thing is <strong>offline-testable</strong>: the embedder, vector store, and LLM are interfaces chosen by env. The default is a deterministic hash embedder + an in-memory store, so the tests and the eval run with no API key and no database. Production swaps in OpenAI embeddings + <strong>pgvector</strong> on Postgres.</p>
+<p>
+  Every answer carries citations built from the chunks that were actually
+  retrieved (source, chunk id, score, snippet) — not whatever the model typed —
+  so there's a real audit trail. And the whole thing is{" "}
+  <strong>offline-testable</strong>: the embedder, vector store, and LLM are
+  interfaces chosen by env. The default is a deterministic hash embedder + an
+  in-memory store, so the tests and the eval run with no API key and no
+  database. Production swaps in OpenAI embeddings + <strong>pgvector</strong> on
+  Postgres.
+</p>
 
-<p>A bug worth sharing: the offline guardrail once had a false positive — with a small 256-dim hash embedder, hash collisions let an off-topic question score above the threshold, so it answered when it should have refused. The fix was to make the offline embedder more discriminative (4096 dims + stopword filtering). The lesson: <em>a guardrail is only as good as the signal it gates on.</em> I also hit the classic pgvector gotcha — the native binary is tied to a Postgres major version (built for pg17, wouldn't load on pg16) — which is exactly why retrieval sits behind a <code>VectorStore</code> interface: dev and CI use the in-memory store, production uses pgvector, and an infra mismatch never blocks development.</p>
+<p>
+  A bug worth sharing: the offline guardrail once had a false positive — with a
+  small 256-dim hash embedder, hash collisions let an off-topic question score
+  above the threshold, so it answered when it should have refused. The fix was
+  to make the offline embedder more discriminative (4096 dims + stopword
+  filtering). The lesson:{" "}
+  <em>a guardrail is only as good as the signal it gates on.</em> I also hit the
+  classic pgvector gotcha — the native binary is tied to a Postgres major
+  version (built for pg17, wouldn't load on pg16) — which is exactly why
+  retrieval sits behind a <code>VectorStore</code> interface: dev and CI use the
+  in-memory store, production uses pgvector, and an infra mismatch never blocks
+  development.
+</p>
 
 <h2>Try it</h2>
 
 <p>It runs in 30 seconds with no setup:</p>
 
-<pre><code>npm install &amp;&amp; npm start   # offline: in-memory store + extractive answers
-</code></pre>
+<pre>
+  <code>
+    npm install &amp;&amp; npm start # offline: in-memory store + extractive
+    answers
+  </code>
+</pre>
 
 <ul>
-<li><strong>Source:</strong> <a href="https://github.com/Shailesh93602/grounded">github.com/Shailesh93602/grounded</a></li>
+  <li>
+    <strong>Source:</strong>{" "}
+    <a href="https://github.com/Shailesh93602/grounded">
+      github.com/Shailesh93602/grounded
+    </a>
+  </li>
 </ul>
 
-<p>If you're adding AI to a product, the question that actually matters isn't "can it answer" — it's "what does it do when it shouldn't, and will you know if it regresses." Build those in from the start. Thanks for reading!</p>
+<p>
+  If you're adding AI to a product, the question that actually matters isn't
+  "can it answer" — it's "what does it do when it shouldn't, and will you know
+  if it regresses." Build those in from the start. Thanks for reading!
+</p>

--- a/e2e/mobile-overflow.spec.ts
+++ b/e2e/mobile-overflow.spec.ts
@@ -29,7 +29,9 @@ test.describe("mobile: no horizontal scroll", () => {
   test.use({ viewport: MOBILE });
 
   for (const route of ALL_ROUTES) {
-    test(`${route} does not scroll sideways at ${MOBILE.width}px`, async ({ page }) => {
+    test(`${route} does not scroll sideways at ${MOBILE.width}px`, async ({
+      page,
+    }) => {
       await page.goto(route, { waitUntil: "domcontentloaded" });
       await page.waitForLoadState("networkidle").catch(() => {});
 
@@ -48,13 +50,13 @@ test.describe("mobile: no horizontal scroll", () => {
 
       expect(
         result.scrolledX,
-        `page scrolled ${result.scrolledX}px sideways — a user can swipe the layout off-screen`,
+        `page scrolled ${result.scrolledX}px sideways — a user can swipe the layout off-screen`
       ).toBe(0);
 
       // 1px of slack for sub-pixel rounding on fractional layouts.
       expect(
         result.scrollWidth,
-        `scrollWidth ${result.scrollWidth} exceeds viewport ${result.viewportWidth}`,
+        `scrollWidth ${result.scrollWidth} exceeds viewport ${result.viewportWidth}`
       ).toBeLessThanOrEqual(result.viewportWidth + 1);
     });
   }
@@ -68,7 +70,10 @@ test.describe("mobile: no horizontal scroll", () => {
     await expect(openButton).toBeVisible();
     await openButton.click();
 
-    const drawerLink = page.getByRole("link", { name: "Portfolio", exact: true });
+    const drawerLink = page.getByRole("link", {
+      name: "Portfolio",
+      exact: true,
+    });
     await expect(drawerLink).toBeVisible();
 
     await page.getByRole("button", { name: /close menu/i }).click();
@@ -81,6 +86,8 @@ test.describe("mobile: no horizontal scroll", () => {
       window.scrollTo(0, 0);
       return x;
     });
-    expect(scrolledX, "closing the drawer reintroduced horizontal scroll").toBe(0);
+    expect(scrolledX, "closing the drawer reintroduced horizontal scroll").toBe(
+      0
+    );
   });
 });

--- a/e2e/portfolio-detail.spec.ts
+++ b/e2e/portfolio-detail.spec.ts
@@ -21,9 +21,7 @@ test.describe("Portfolio Detail", () => {
     // contains "eduscale" (live URL, GitHub, etc). And scroll the card
     // into view — on mobile the tag-filter chips above otherwise
     // intercept pointer events when Playwright auto-scrolls.
-    const eduscaleLink = page
-      .locator('a[href="/portfolio/eduscale"]')
-      .first();
+    const eduscaleLink = page.locator('a[href="/portfolio/eduscale"]').first();
 
     if ((await eduscaleLink.count()) > 0) {
       await eduscaleLink.scrollIntoViewIfNeeded();

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -41,8 +41,7 @@ export const PROFILE = {
     country: "India",
     // Canonical one-line string for metadata "addressLocality / addressRegion"
     displayShort: "Ahmedabad, Gujarat, India",
-    displayLong:
-      "Based in Ahmedabad, Gujarat, India — originally from Patan",
+    displayLong: "Based in Ahmedabad, Gujarat, India — originally from Patan",
   },
 
   education: {

--- a/tests/accessibility.md
+++ b/tests/accessibility.md
@@ -1,13 +1,16 @@
 # Accessibility Test Cases
 
 ## Test: Keyboard Navigation
+
 1. User navigates site using keyboard only.
 2. All interactive elements are accessible and usable.
 
 ## Test: Screen Reader Compatibility
+
 1. User accesses site with a screen reader.
 2. All content is announced and navigable.
 
 ## Test: Color Contrast
+
 1. User views site with color contrast analyzer.
 2. All text is readable against backgrounds.

--- a/tests/contact-form.md
+++ b/tests/contact-form.md
@@ -1,14 +1,17 @@
 # Contact Form Test Cases
 
 ## Test: Successful Submission
+
 1. User fills out all required fields on the contact form.
 2. User submits the form.
 3. Success message is displayed, and data is sent correctly.
 
 ## Test: Validation Errors
+
 1. User submits form with missing or invalid data.
 2. Appropriate error messages are shown for each invalid field.
 
 ## Test: Spam Protection
+
 1. User attempts to submit form repeatedly or with typical spam data.
 2. Anti-spam measures (honeypot, captcha, rate limiting) are triggered if implemented.

--- a/tests/homepage.md
+++ b/tests/homepage.md
@@ -1,14 +1,17 @@
 # Homepage Test Cases
 
 ## Test: Load Homepage
+
 1. User navigates to the root URL.
 2. Homepage loads without errors.
 3. Key sections (header, about, projects, contact) are visible.
 
 ## Test: Responsive Design
+
 1. User resizes browser window or opens homepage on mobile.
 2. All elements rearrange appropriately and remain readable.
 
 ## Test: Navigation Links
+
 1. User clicks navigation links (e.g., About, Projects, Contact).
 2. Correct section or page loads.

--- a/tests/projects-section.md
+++ b/tests/projects-section.md
@@ -1,13 +1,16 @@
 # Projects Section Test Cases
 
 ## Test: Project Display
+
 1. User navigates to Projects section.
 2. All projects are displayed with images, description, and links.
 
 ## Test: Project Links
+
 1. User clicks on a project link.
 2. Project detail page or external link opens correctly.
 
 ## Test: Filter/Sort (if implemented)
+
 1. User interacts with filter or sort options.
 2. Project list updates accordingly.


### PR DESCRIPTION
Same problem the KhataGO repo had, found the same way.

The `format` and `format:check` scripts existed and **nothing ran them**, so 26 files had drifted out of Prettier style and the diff noise was landing in the review of whatever unrelated change touched those files next.

`format:check` now runs in CI next to lint and type-check. **That step is the part that prevents recurrence** — reformatting the 26 files just pays off what accumulated.

## The generated artifacts stay excluded

`data/blog-manifest.json` and `data/statistics-snapshot.json` are written by `postbuild` and by the stats workflow, so formatting them would **fail CI on the next regeneration**. That's exactly why `.prettierignore` already lists them, and it's worth not undoing by reflex when adding the check.

**No source behaviour changes** — 269 tests, lint and type-check unchanged, build clean.