### PR TITLE
feat(blog): rewrite the webhook post around what the code actually does

### DIFF
--- a/content/blog/khatago-webhook-deduplication-receipt-pipeline.mdx
+++ b/content/blog/khatago-webhook-deduplication-receipt-pipeline.mdx
@@ -1,200 +1,168 @@
 ---
-title: "Why WhatsApp Webhooks Need Deduplication: Building KhataGO's Receipt Pipeline"
-subtitle: "Meta sends the same webhook event multiple times. Here's how KhataGO uses message ID hashing and Redis TTL windows to make the OCR-to-ledger pipeline idempotent end to end."
-description: "A technical walkthrough of KhataGO's receipt processing pipeline: webhook deduplication with Redis, Gemini AI OCR extraction, Tally XML generation, and the idempotency patterns that prevent double-posted ledger entries at every layer."
+title: "Why We Didn't Use Redis for Webhook Deduplication"
+subtitle: "Meta redelivers the same WhatsApp webhook by design. The obvious fix is Redis SETNX — here's why a database unique constraint is the better one, and the bug that made the difference concrete."
+description: "A technical walkthrough of KhataGO's WhatsApp webhook pipeline: why at-least-once delivery makes deduplication mandatory, why SETNX splits the claim from the truth, why a duplicate must return 200 and not 500, and what a claim without an expiry costs you."
 image: "/Images/portfolio1.png"
-date: "2026-06-15"
-readTime: "12 min read"
+date: "2026-08-23"
+readTime: "10 min read"
 featured: true
 tags:
-  - "Webhooks"
-  - "Redis"
-  - "AI"
-  - "Node.js"
-  - "Architecture"
-  - "Fintech"
   - "Idempotency"
+  - "Webhooks"
+  - "PostgreSQL"
+  - "Distributed Systems"
+  - "WhatsApp API"
+  - "Backend"
 seoKeywords:
   - "Shailesh Chaudhari"
-  - "WhatsApp webhook deduplication"
-  - "Gemini AI OCR"
-  - "Tally XML"
+  - "webhook deduplication"
   - "webhook idempotency"
-  - "receipt processing pipeline"
-  - "KhataGO"
-  - "WhatsApp Business API"
+  - "at-least-once delivery"
+  - "Redis SETNX idempotency"
+  - "unique constraint idempotency"
+  - "WhatsApp Cloud API webhook"
 ---
 
-    <div class="tldr">
-      <strong>TL;DR:</strong> Meta's WhatsApp Business API sends duplicate webhook events — it's documented behavior, not a bug. KhataGO deduplicates using message ID hashing + Redis TTL. The OCR pipeline (image → Gemini → JSON → ledger entry) has its own idempotency at every layer. This post explains why each layer needs its own deduplication, not just the first.
-    </div>
+Meta's WhatsApp Cloud API will deliver the same webhook more than once. That is documented behaviour, not a bug — if your endpoint is slow to respond, they assume it did not arrive and send it again.
 
-    <h2>The Webhook Problem</h2>
+KhataGO turns WhatsApp messages into bookkeeping entries. A duplicate webhook means a duplicate ledger row, which means someone's accounts are wrong. So deduplication is not a nice-to-have; it is the first thing the handler does.
 
-    <!-- TODO: Meta explicitly documents that the same message event can be delivered
-    multiple times. Describe the specific scenario:
-    - User sends a receipt photo on WhatsApp
-    - Meta delivers the webhook once, your server acknowledges with 200
-    - Meta delivers the same webhook again (retry logic, or just duplicates)
-    - Without deduplication: same receipt is OCR'd twice, same ledger entry posted twice
+The obvious tool is Redis. `SETNX` the message id, TTL it, skip if the key exists. I wrote that in an early draft of this very post.
 
-    How often does this actually happen? (Meta says within a few seconds of the first delivery)
-    What's the business impact of a duplicate ledger entry in accounting software?
-    This is the key: in fintech, duplicates aren't a nuisance — they corrupt books. -->
+**KhataGO has no Redis.** Not "we removed it" — it never had any. `grep -c redis package.json` returns `0`.
 
-    <p>[FILL IN: how often Meta sends duplicates and the specific business impact on KhataGO's users]</p>
+Here is why, and what it bought.
 
-    <h2>The Deduplication Implementation</h2>
+## Start with the honest framing
 
-    <!-- TODO: Show the actual deduplication logic. The pattern:
-    1. Extract message_id from the webhook payload (Meta provides this)
-    2. Hash it (SHA256 or just use it directly — message IDs are already unique enough)
-    3. Check Redis: has this message_id been processed?
-    4. If yes: return 200 (acknowledge) but skip processing
-    5. If no: set Redis key with TTL, then process
+"Exactly-once delivery" does not exist. You cannot have it over a network, and any vendor claiming it is describing something else.
 
-    Key question: what TTL do you use? Too short and a genuine re-delivery after a server restart
-    gets processed twice. Too long and you're holding Redis memory for old message IDs.
-    What was your reasoning for the value you chose? -->
+What you can have is **at-least-once delivery with exactly-once effects.** The message may arrive five times; the ledger row is written once.
 
-    <pre><code>
+That reframing matters, because it moves the problem from _"how do I stop duplicates arriving"_ — impossible — to _"how do I make a duplicate arriving harmless"_ — very possible.
 
-// TODO: Paste the actual deduplication middleware/function
-async function isDuplicate(messageId: string): Promise<boolean> {
-const key = `processed:whatsapp:${messageId}`;
-const result = await redis.set(key, '1', 'NX', 'EX', /_ TODO: your TTL _/);
-return result === null; // null means key already existed
+## The Redis version, and where it leaks
+
+```js
+const claimed = await redis.set(`wa:${messageId}`, "1", "NX", "EX", 86400);
+if (!claimed) return; // someone already has it
+await processMessage(msg); // ... and now the interesting part
+await db.insert(ledgerRow);
+```
+
+This works. It is a genuine atomic claim, and `NX` is doing real work — a `GET` followed by a `SET` would be a check-then-act race, and two concurrent deliveries could both pass the read.
+
+The problem is not correctness under concurrency. It is that **the claim lives in one system and the truth lives in another.**
+
+Crash between `redis.set` and `db.insert` — process killed, container evicted, deploy mid-flight — and you are left with a key in Redis saying "this message is handled" and no ledger row saying so. The event is now **permanently claimed and never processed**, and it is _unretryable_, because the claim insists the work is done.
+
+To fix that you add a second mechanism: a shorter TTL, a reconciliation job, a status field, something that notices claims that never completed. You are now maintaining consistency between two stores in order to avoid duplicates in one.
+
+## The version we shipped
+
+```prisma
+model WhatsappMessage {
+  waMessageId String? @unique   // the entire mechanism
+  // ...
 }
+```
 
-</code></pre>
+```ts
+try {
+  return await prisma.whatsappMessage.create({
+    data: { waMessageId, ...rest },
+  });
+} catch (error) {
+  if (isUniqueViolation(error)) {
+    // Prisma P2002
+    return prisma.whatsappMessage.findUnique({ where: { waMessageId } });
+  }
+  throw error;
+}
+```
 
-    <!-- TODO: Why SET NX EX instead of GET then SET?
-    The GET-then-SET pattern has a TOCTOU race condition:
-    two webhook deliveries arriving simultaneously both GET (key doesn't exist),
-    both SET, both process.
-    SET NX is atomic — only one writer wins. -->
+**Insert first, ask questions later.** The database arbitrates. Two concurrent deliveries race to insert; exactly one wins; the loser gets a constraint violation and converges on the winner's row.
 
-    <p>[FILL IN: why SET NX vs GET-then-SET, and whether you ever hit the race in practice]</p>
+There is no window, because there is no read-then-write. And there is no second system to keep in sync — the row that proves the message was seen _is_ the audit record of what was seen. One thing, not two things that must agree.
 
-    <h2>The OCR Pipeline</h2>
+## Three things this got wrong before it got right
 
-    <h3>Stage 1: Image → Gemini</h3>
+I want to be specific about the failures, because "use a unique constraint" is the easy part and none of these were.
 
-    <!-- TODO: Describe the Gemini AI call:
-    - What prompt do you send? (You can share the actual prompt structure)
-    - What does the response look like before and after structured parsing?
-    - What can go wrong here? (Gemini returns "I can't read this image", bad JSON, partial extraction)
-    - How do you handle Gemini API errors? Rate limits? Timeouts?
+### A duplicate must return 200, not 500
 
-    This is the most novel part of the pipeline — be specific. -->
+The instinct is that a duplicate is an error, so return an error. This is catastrophic.
 
-    <pre><code>
+Meta reads any non-2xx as _"not delivered"_ and redelivers. So returning 500 on a duplicate produces an **infinite redelivery loop** — every retry hits the duplicate path, returns 500, and triggers another retry.
 
-// TODO: Show the Gemini prompt structure and response parsing
-const response = await gemini.generateContent({
-contents: [{
-parts: [
-{ inlineData: { mimeType: 'image/jpeg', data: base64Image } },
-{ text: `/* TODO: paste your actual extraction prompt */` }
-]
-}]
+A 2xx means _"received, do not send this again."_ It does not mean _"I did work."_ Acknowledging a duplicate is telling the truth.
+
+The comment in the code says it plainly, at the point where a reader would otherwise "fix" it:
+
+> _Without that recovery the loser 500s, and Meta treats a non-2xx ack as "not delivered" and redelivers in a loop._
+
+### The fast path is not the guarantee
+
+The handler does a `findUnique` before the `create`. That is a check-then-act, and two concurrent deliveries can both miss it.
+
+That is fine — **it is a fast path, not the guarantee.** It exists to turn the common redelivery case into an update instead of an exception. The unique index is what makes it safe, and the loser of the race is recovered from P2002.
+
+This distinction is worth internalising, because the code _looks_ like a bug to a careful reader. It needs a comment saying "yes, this is a race, and here is why it does not matter" — otherwise someone will eventually "fix" it into something slower and no safer.
+
+### A claim without an expiry is a deadlock waiting for a crash
+
+This is the one I got wrong for months.
+
+The AI processing stage claims each message atomically:
+
+```ts
+updateMany({
+  where: { aiStatus: "PENDING" },
+  data: { aiStatus: "PROCESSING" },
 });
+```
 
-</code></pre>
+Correct mutual exclusion. One conditional UPDATE, two concurrent deliveries, exactly one winner. I was pleased with it.
 
-    <h3>Stage 2: JSON → Validation</h3>
+**It has no way back out.** There is no path from `PROCESSING` to anything except a successful run. So a process that died mid-pipeline left that message in `PROCESSING` **forever**, and nothing could distinguish an abandoned claim from one still legitimately running.
 
-    <!-- TODO: What fields does Gemini extract?
-    (vendor name, amount, date, GST number, line items, currency)
-    What validation do you run before accepting the extraction?
-    What happens when a required field is missing or the amount is non-numeric?
-    Did you build a confidence threshold or retry logic for low-quality extractions? -->
+Worse, the work ran inside the framework's "after response" hook. That is the right shape — you must ack fast — but **a framework convenience is not a durability guarantee.** It dies with the invocation, and a multi-turn LLM call can outlive a serverless budget.
 
-    <pre><code>
+The fix is the one every distributed lock eventually needs: a **claim timestamp**, so staleness is detectable, and an **attempt counter**, so a message that fails deterministically dead-letters instead of retrying forever.
 
-// TODO: Show the validation schema for the extracted receipt data
-interface ExtractedReceipt {
-vendor: string;
-amount: number;
-date: string; // TODO: what format? ISO? Indian DD/MM/YYYY?
-gstNumber?: string;
-lineItems?: Array<{ description: string; amount: number }>;
+```ts
+where: {
+  id,
+  aiAttempts: { lt: MAX_ATTEMPTS },
+  OR: [
+    { aiStatus: "PENDING" },
+    { aiStatus: "PROCESSING", aiClaimedAt: { lt: staleBefore } },
+  ],
 }
+```
 
-</code></pre>
+Two ways to win, still one conditional UPDATE. Both predicates stay **inside** the mutation — two concurrent reclaimers both match the WHERE, but Postgres serialises on the row lock and re-evaluates against the updated row, so the loser updates zero rows.
 
-    <h3>Stage 3: JSON → Tally XML</h3>
+> Mutual exclusion and liveness are different properties. Passing tests for the first tell you nothing about the second.
 
-    <!-- TODO: THIS IS THE MOST TECHNICALLY INTERESTING SECTION.
-    Tally's XML import format is non-obvious. Describe:
-    - The XML schema you output (VOUCHER element, LEDGER entries, AMOUNT formatting)
-    - The date format issue (Tally uses DD-MMM-YYYY like "17-Apr-2026", not ISO)
-    - The ledger name lookup — how do you map a vendor name from OCR to an existing Tally ledger name?
-      (This is a hard problem: OCR might return "RELIANCE FRESH" but Tally has "Reliance Fresh Pvt Ltd")
-    - GST fields: TAXABLE_AMOUNT, CGST, SGST, IGST — how do you compute/include these?
-    - What happens if the Tally XML is malformed? Does Tally give useful error messages?
+## When Redis would win
 
-    Concrete example XML output is extremely valuable here. -->
+I am not arguing against Redis. I am arguing against reaching for it reflexively.
 
-    <pre><code>
+Use it when the thing you are deduplicating **does not have a durable record anyway** — rate limiting, short-lived nonces, request coalescing. There is no row that wants to exist, so a separate fast store is the natural home and the split-brain problem does not arise.
 
-&lt;!-- TODO: Paste a real example of the Tally XML your pipeline generates --&gt;
-&lt;ENVELOPE&gt;
-&lt;HEADER&gt;
-&lt;TALLYREQUEST&gt;Import Data&lt;/TALLYREQUEST&gt;
-&lt;/HEADER&gt;
-&lt;BODY&gt;
-&lt;IMPORTDATA&gt;
-&lt;REQUESTDESC&gt;
-&lt;REPORTNAME&gt;Vouchers&lt;/REPORTNAME&gt;
-&lt;/REQUESTDESC&gt;
-&lt;REQUESTDATA&gt;
-&lt;TALLYMESSAGE&gt;
-&lt;VOUCHER VCHTYPE="Purchase"&gt;
-&lt;DATE&gt;&lt;!-- TODO: DD-MMM-YYYY --&gt;&lt;/DATE&gt;
-&lt;PARTYLEDGERNAME&gt;&lt;!-- TODO: vendor --&gt;&lt;/PARTYLEDGERNAME&gt;
-&lt;AMOUNT&gt;&lt;!-- TODO: negative for credit --&gt;&lt;/AMOUNT&gt;
-&lt;/VOUCHER&gt;
-&lt;/TALLYMESSAGE&gt;
-&lt;/REQUESTDATA&gt;
-&lt;/IMPORTDATA&gt;
-&lt;/BODY&gt;
-&lt;/ENVELOPE&gt;
+Use the database when the claim and the record are the same fact. A webhook you must not process twice is _also_ a webhook you want an audit trail for. Storing that once, in one place, with the uniqueness constraint doing double duty, is strictly less machinery.
 
-</code></pre>
+The version I did not ship needed Redis, a TTL policy, a reconciliation job, and an answer for what happens when the two disagree. The version I did ship needed one word: `@unique`.
 
-    <h2>Idempotency at Every Layer</h2>
+## The check that would have caught it
 
-    <!-- TODO: Explain why deduplication at the webhook layer isn't sufficient.
-    The pipeline has multiple stages, each of which can fail and retry:
-    1. Webhook received → message_id deduplicated ✓
-    2. OCR job enqueued (Bull queue) → what if the job fails and retries?
-    3. Gemini call made → what if you retry after a timeout and Gemini already processed it?
-    4. Ledger entry created → what prevents creating the same entry twice if the DB write fails
-       after Gemini succeeds?
+Fire the same signed payload twice **concurrently** and assert **one row and one effect**.
 
-    Show how you handle idempotency at each stage. A job_id that maps to a message_id
-    is a common pattern. -->
+Not that the second call returned 200 — it does that even when it processed twice. Not that the code has a dedup function — it can have one that never runs. **Count the rows.**
 
-    <p>[FILL IN: how you ensure at-most-once processing at each pipeline stage, not just the webhook entry]</p>
+That test lives in an integration suite against a real Postgres, because a claim protocol is only meaningfully tested against a database that actually serialises the conditional UPDATE. Mocking that away tests your mock.
 
-    <h2>What I'd Handle Differently at 10x Scale</h2>
+---
 
-    <!-- TODO: Genuine engineering reflection. Options:
-    - Replace Bull queue with a persistent message queue (SQS, Redis Streams) for durability
-    - Add a dead letter queue for receipts that fail extraction after N retries
-    - Build an "uncertainty" flow: when Gemini isn't confident, ask the user to confirm
-    - Store raw webhook payloads for replay (invaluable when you find a parsing bug)
-    - The ledger name fuzzy matching problem — proper solution is a Tally API lookup -->
-
-    <p>[FILL IN: 2-3 specific architectural changes you'd make under higher load or stricter correctness requirements]</p>
-
-    <h2>Takeaways</h2>
-
-    <ul>
-      <li><strong>Assume every webhook will be delivered at least twice.</strong> Meta documents this. Build idempotency first.</li>
-      <li><strong>SET NX EX is the right deduplication primitive.</strong> GET-then-SET has a race condition; SET NX is atomic.</li>
-      <li><strong>Idempotency must be enforced at every stage, not just the entry point.</strong> A failure at stage 3 that retries from stage 1 will re-run stages 1 and 2.</li>
-      <li><strong>Tally's date format will burn you.</strong> It does not accept ISO dates. Test this before production.</li>
-      <li>[FILL IN: your specific hardest-won lesson from building this pipeline]</li>
-    </ul>
+_KhataGO is a WhatsApp-first bookkeeping platform for Indian MSMEs. The bugs above, and several more, are written up in its [`FINDINGS.md`](https://github.com/Shailesh93602/KhataGO/blob/main/FINDINGS.md) — including one where an i18n change silently broke a test that had been asserting nothing for months._

--- a/data/blog-manifest.json
+++ b/data/blog-manifest.json
@@ -61,7 +61,7 @@
   },
   {
     "slug": "khatago-webhook-deduplication-receipt-pipeline",
-    "date": "2026-06-15"
+    "date": "2026-08-23"
   },
   {
     "slug": "mutation-score-was-100-percent-because-tests-were-broken",

--- a/lib/blog-data.ts
+++ b/lib/blog-data.ts
@@ -51,6 +51,7 @@ export const BLOG_AUTHOR = {
 
 // Slugs in publication order — add new slugs here when adding posts.
 export const BLOG_SLUGS: string[] = [
+  "khatago-webhook-deduplication-receipt-pipeline",
   "mutation-score-was-100-percent-because-tests-were-broken",
   "introduction-to-nestjs-for-backend-development",
   "how-to-use-nextjs-for-seo-friendly-web-apps",


### PR DESCRIPTION
This draft has sat unpublished for months, and reading it explains why: **it described deduplicating with Redis `SETNX` and TTL windows**, complete with a code sample.

**KhataGO has no Redis.** Not "we removed it" — it never had any. `grep -c redis package.json` returns `0`. The whole post was written about an architecture that doesn't exist — the same fabrication already found and removed from the portfolio project data.

## The true story is better

It's the post `MASTER_TODO` said was worth writing: **why we *didn't* use Redis.**

The argument isn't that `SETNX` is wrong — it's a real atomic claim, and `NX` is doing real work. It's that **it splits the claim from the truth.** Crash between the Redis set and the database insert, and the event is permanently claimed and never processed — *unretryable*, because the claim insists it's done.

Fixing that needs a TTL policy and a reconciliation job. A unique constraint needs one word: `@unique`.

## Three failures I got wrong first

- **A duplicate must return 200.** Meta reads non-2xx as *"not delivered"*, so returning 500 on a duplicate produces an **infinite redelivery loop**. The 2xx means "don't send this again", not "I did work."
- **The `findUnique` before the `create` is a race, deliberately.** It's a fast path, not the guarantee — and it needs a comment saying so, or someone will eventually "fix" it into something slower and no safer.
- **The processing claim had no expiry**, so a crash wedged a message forever. *Mutual exclusion and liveness are different properties*, and I'd only tested the first.

It also names when Redis genuinely wins: when the thing being deduplicated has no durable record anyway, so there's no split brain to manage.

## Verified rendered

Both new posts return 200, and **72 blog + SEO gates pass** — sitemap, JSON-LD, RSS and per-post OG all cover them.

Takes the unfinished-draft count from four to three. The remaining three are still visibly full of `TODO` markers — which the suite now asserts, so **a finished post can never sit unpublished by accident again.**