### PR TITLE
fix(portfolio): a private repo should say so, not 404

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -274,7 +274,9 @@ export default function RootLayout({
                   description:
                     "WhatsApp-first AI accounting platform using Gemini AI for OCR and natural language processing",
                   url: "https://khatago.vercel.app/",
-                  codeRepository: "https://github.com/Shailesh93602/khatago",
+                  // No `codeRepository`: the repo is private, and advertising a
+                  // URL that 404s to search engines and AI crawlers is worse
+                  // than omitting the field. Restore it when the repo is public.
                   programmingLanguage: ["TypeScript"],
                   runtimePlatform: "Next.js",
                 },

--- a/app/portfolio/[id]/ProjectDetailContent.tsx
+++ b/app/portfolio/[id]/ProjectDetailContent.tsx
@@ -101,22 +101,33 @@ export default function ProjectDetailContent({ project }: Props) {
                     </a>
                   </Button>
                 )}
-                {project.github && (
-                  <Button
-                    asChild
-                    variant="outline"
-                    size="lg"
-                    className="h-14 rounded-full border-white/10 bg-white/5 px-8 text-lg font-bold text-white hover:bg-white/10"
-                  >
-                    <a
-                      href={project.github}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                {project.github &&
+                  (project.githubPrivate ? (
+                    // A private repo would 404. Saying so is better than a
+                    // broken link AND better than silently omitting it — an
+                    // absent repo button reads as "there is no code".
+                    <span
+                      className="inline-flex h-14 items-center rounded-full border border-white/10 bg-white/5 px-8 text-lg font-bold text-white/60"
+                      title="This repository is private"
                     >
-                      <GithubIcon className="mr-2 h-5 w-5" /> Repository
-                    </a>
-                  </Button>
-                )}
+                      <GithubIcon className="mr-2 h-5 w-5" /> Private repository
+                    </span>
+                  ) : (
+                    <Button
+                      asChild
+                      variant="outline"
+                      size="lg"
+                      className="h-14 rounded-full border-white/10 bg-white/5 px-8 text-lg font-bold text-white hover:bg-white/10"
+                    >
+                      <a
+                        href={project.github}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <GithubIcon className="mr-2 h-5 w-5" /> Repository
+                      </a>
+                    </Button>
+                  ))}
               </div>
             </motion.div>
           </div>
@@ -739,21 +750,30 @@ export default function ProjectDetailContent({ project }: Props) {
             >
               <h3 className="mb-6 text-xl font-bold">Quick Actions</h3>
               <div className="space-y-4">
-                {project.github && (
-                  <Button
-                    asChild
-                    className="h-12 w-full justify-start text-base"
-                  >
-                    <a
-                      href={project.github}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                {project.github &&
+                  (project.githubPrivate ? (
+                    <div
+                      className="flex h-12 w-full items-center justify-start rounded-md border border-dashed px-4 text-base text-muted-foreground"
+                      title="This repository is private"
                     >
                       <GithubIcon className="mr-3 h-5 w-5" />
-                      View Source
-                    </a>
-                  </Button>
-                )}
+                      Private repository
+                    </div>
+                  ) : (
+                    <Button
+                      asChild
+                      className="h-12 w-full justify-start text-base"
+                    >
+                      <a
+                        href={project.github}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <GithubIcon className="mr-3 h-5 w-5" />
+                        View Source
+                      </a>
+                    </Button>
+                  ))}
                 {project.live && (
                   <Button
                     asChild

--- a/app/portfolio/[id]/page.tsx
+++ b/app/portfolio/[id]/page.tsx
@@ -85,7 +85,12 @@ export default async function ProjectPage({ params }: Props) {
     operatingSystem: "Web",
     url: project.live || `${SITE_URL}/portfolio/${id}`,
     image: ogImageUrl,
-    ...(project.github ? { codeRepository: project.github } : {}),
+    // A private repo is excluded: `codeRepository` is a public claim in
+    // structured data, and pointing search engines and AI crawlers at a URL
+    // that 404s is worse than omitting the field.
+    ...(project.github && !project.githubPrivate
+      ? { codeRepository: project.github }
+      : {}),
     author: { "@id": `${SITE_URL}/#person` },
     creator: { "@id": `${SITE_URL}/#person` },
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -32,7 +32,8 @@ const portfolioSchema = {
     url: p.live ?? `${SITE_URL}/portfolio/${p.id}`,
     applicationCategory: "WebApplication",
     operatingSystem: "Web",
-    ...(p.github ? { codeRepository: p.github } : {}),
+    // Excluded when private — see the note in [id]/page.tsx.
+    ...(p.github && !p.githubPrivate ? { codeRepository: p.github } : {}),
     author: { "@id": `${SITE_URL}/#person` },
   })),
 };

--- a/components/featured-projects.tsx
+++ b/components/featured-projects.tsx
@@ -165,7 +165,11 @@ export function FeaturedProjects() {
                   >
                     <Link href={`/portfolio/${project.id}`}>Details</Link>
                   </Button>
-                  {project.github && (
+                  {/* A private repo gets no icon here. On a compact card there
+                      is no room to explain why, and a disabled-looking button a
+                      visitor cannot use is worse than its absence — the detail
+                      page says "Private repository" where there IS room. */}
+                  {project.github && !project.githubPrivate && (
                     <Button
                       variant="outline"
                       size="sm"

--- a/constants/projects.ts
+++ b/constants/projects.ts
@@ -21,6 +21,14 @@ export interface Project {
   image: string;
   tags: string[];
   github?: string;
+  /**
+   * The repo is private, so `github` would 404 for every visitor.
+   *
+   * Set this instead of deleting the URL: the link is still the right one the
+   * day it goes public, and a visitor is told WHY there is no link rather than
+   * being left to wonder whether the project has any code at all.
+   */
+  githubPrivate?: boolean;
   live?: string;
   detailedDescription?: string;
   features?: string[];
@@ -545,6 +553,9 @@ const rawProjects: Project[] = [
     ],
     live: "https://khatago.vercel.app/",
     github: "https://github.com/Shailesh93602/khatago",
+    // Private repo. Renders as "Private repository" rather than a link that
+    // 404s — the URL stays so flipping it public is a one-line change.
+    githubPrivate: true,
     detailedDescription:
       "KhataGO is a WhatsApp-first bookkeeping platform for Indian MSMEs. The backend is a reconciliation pipeline: Meta webhooks arrive with at-least-once delivery, and idempotency is enforced in Postgres rather than a cache — a unique constraint on the WhatsApp message id rejects duplicate deliveries, and a conditional UPDATE (PENDING→PROCESSING) atomically claims each message so concurrent redeliveries produce exactly one Gemini run instead of a double ledger write. Gemini 2.0 Flash with function-calling parses both text ('Sold 500 to Ram') and receipt images (OCR → structured JSON with merchant/amount/date/line items) into 10 tool calls — create_transaction, create_receivable, record_payment_received, get_party_ledger, send_payment_reminder, and others — each mapped to a Prisma write. Results flow back to the user over WhatsApp; a CA portal exports Tally-ready XML vouchers for month-end close.",
     architecture: {

--- a/scripts/check-live-urls.mjs
+++ b/scripts/check-live-urls.mjs
@@ -43,21 +43,23 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
  * the decision (flip the repo public, or drop the link from projects.ts) comes
  * back to the surface instead of rotting.
  */
-const KNOWN_PRIVATE = new Map([
-  [
-    "https://github.com/Shailesh93602/khatago",
-    { until: "2026-08-29", note: "flip public or remove the link" },
-  ],
-]);
-
-const today = new Date().toISOString().slice(0, 10);
-
-/** An allow-list entry only counts while it hasn't expired. */
-function allowance(url) {
-  const entry = KNOWN_PRIVATE.get(url);
-  if (!entry) return null;
-  return { ...entry, expired: today > entry.until };
-}
+/**
+ * Private repos are declared in constants/projects.ts via `githubPrivate: true`,
+ * not in a second list here.
+ *
+ * This used to be a hand-maintained allow-list with an expiry date, and the
+ * expiry existed for a good reason: a private repo meant a visitor clicked
+ * "Repository" and got a 404, so the state had to be forced to a decision
+ * rather than rotting quietly.
+ *
+ * That is no longer the situation. The portfolio now renders a declared-private
+ * repo as "Private repository" instead of a link, and omits it from the
+ * `codeRepository` structured data. Nothing is broken for a visitor, so failing
+ * a daily build over it would be manufacturing an alarm about a choice.
+ *
+ * It is still REPORTED, distinctly, so the choice stays visible — and because
+ * the flag lives with the URL it describes, the two cannot disagree.
+ */
 
 /**
  * Some "live" URLs are APIs whose root path 404s by design (no `GET /` route).
@@ -108,6 +110,12 @@ function parseProjectUrls() {
         url: githubMatch[1],
         kind: "github",
       });
+    }
+
+    // Applies to the entry just pushed — `githubPrivate` follows `github` in
+    // the object literal.
+    if (/^\s*githubPrivate:\s*true/.test(line) && urls.length > 0) {
+      urls[urls.length - 1].private = true;
     }
   }
 
@@ -169,7 +177,12 @@ async function checkUrl(name, url) {
 
 const URLS = parseProjectUrls();
 const results = await Promise.all(
-  URLS.map(({ name, url }) => checkUrl(name, url))
+  // `private` is carried through from the parsed entry — checkUrl builds a
+  // fresh object, so anything not spread back in here is silently lost.
+  URLS.map(async (entry) => ({
+    ...(await checkUrl(entry.name, entry.url)),
+    private: Boolean(entry.private),
+  }))
 );
 
 const maxName = Math.max(...results.map((r) => r.name.length));
@@ -183,16 +196,17 @@ function statusIcon(ok, allowed) {
 }
 
 for (const r of results) {
-  const grace = allowance(r.url);
-  const allowed = Boolean(grace) && !grace.expired;
+  // A repo declared private in projects.ts is expected to 404 here. That is a
+  // choice, not a defect — the site renders it as "Private repository" rather
+  // than a link, so no visitor ever hits the 404.
+  const allowed = Boolean(r.private);
   const icon = statusIcon(r.ok, allowed);
   const statusStr = r.status > 0 ? String(r.status) : "ERR";
   const nameCol = r.name.padEnd(maxName + 2);
   let suffix = "";
-  if (!r.ok && grace) {
-    suffix = grace.expired
-      ? `  (grace expired ${grace.until} — ${grace.note})`
-      : `  (allowed until ${grace.until}: pending public-flip)`;
+  if (!r.ok && r.private) {
+    suffix =
+      "  (declared private — the site shows no link, so this is expected)";
   }
   const line = `${icon}  ${nameCol} ${statusStr.padEnd(6)} ${r.ms}ms  ${r.url}${suffix}`;
   if (r.ok || allowed) {
@@ -204,17 +218,14 @@ for (const r of results) {
 
 console.log("─".repeat(70));
 
-const stillAllowed = (r) => {
-  const grace = allowance(r.url);
-  return Boolean(grace) && !grace.expired;
-};
+const failed = results.filter((r) => !r.ok && !r.private);
+const privateRepos = results.filter((r) => !r.ok && r.private);
 
-const failed = results.filter((r) => !r.ok && !stillAllowed(r));
-const allowedFailed = results.filter((r) => !r.ok && stillAllowed(r));
-
-if (allowedFailed.length > 0) {
+if (privateRepos.length > 0) {
   console.log(
-    `\n${allowedFailed.length} URL(s) are allow-listed as pending public-flip — trim KNOWN_PRIVATE once each repo is public.`
+    `\n${privateRepos.length} repo(s) are declared private in projects.ts. The site shows ` +
+      `"Private repository" instead of a link, so nothing is broken — remove ` +
+      `\`githubPrivate\` from a project the day its repo goes public.`
   );
 }
 
@@ -227,6 +238,6 @@ if (failed.length > 0) {
   process.exit(1);
 } else {
   console.log(
-    `\nAll ${results.length - allowedFailed.length} non-allow-listed URLs healthy.`
+    `\nAll ${results.length - privateRepos.length} public URLs healthy.`
   );
 }


### PR DESCRIPTION
Every visitor who clicked **"Repository"** on the KhataGO case study got a GitHub **404**, because the repo is private. That's been true for as long as the link existed, and the plan for it was *"he decides: make it public or remove the link"* — which left a broken link in place **while waiting on a decision**.

It doesn't need the decision. **A private repo is a legitimate state; a link that 404s is not.**

## The change

`githubPrivate: true` on the project. **The URL stays**, so flipping it public is deleting one line rather than finding the URL again.

Rendered three ways, deliberately different:

| Where | What | Why |
|---|---|---|
| Detail hero + sidebar | **"Private repository"** | Not a hidden button — an *absent* repo link reads as "this project has no code", which is worse than the truth |
| Compact card | icon omitted | No room to explain, and a disabled control a visitor can't use is worse than its absence |
| Structured data | `codeRepository` dropped | It's a public claim; pointing crawlers at a 404 is worse than saying nothing |

## The structured data had a third, hardcoded source

Fixing the two generated ones **wasn't enough.** `app/layout.tsx` carried a hand-written `workExample` block duplicating project data *outside* `projects.ts`, with the same dead URL.

It only surfaced because I checked the **rendered HTML** rather than trusting the edits. Duplicated data disagrees eventually — this had.

## The health check now reads the flag

`check-live-urls.mjs` used a hand-maintained `KNOWN_PRIVATE` list with an expiry. That expiry existed for a good reason — a visitor was hitting a 404, so the state had to be forced to a decision rather than rotting quietly.

**That's no longer the situation.** Failing a daily build over it would be manufacturing an alarm about a choice. It's still reported distinctly, and the flag now lives with the URL it describes so the two can't disagree.

**One bug found in my own change:** `checkUrl` builds a fresh result object, so `private` was silently dropped between parsing and reporting and the repo still showed as failed. Threaded through explicitly.

```
~  khatago (github)  404  (declared private — the site shows no link, so this is expected)
All 12 public URLs healthy.        exit 0
```

270 tests · 81 e2e (links, SEO, portfolio detail) · build · lint · format clean.