### PR TITLE
fix(seo): remove a latency claim that was never measured

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -262,7 +262,17 @@ export default function RootLayout({
                   "@type": "SoftwareSourceCode",
                   name: "EduScale",
                   description:
-                    "Real-time engineering learning platform with coding battles, Redis pub/sub, and <200ms sync latency",
+                    // The "<200ms sync latency" that used to be here was never
+                    // measured. EduScale's own loadtest/README.md exists, in its
+                    // words, "to replace unverified claims in the portfolio" and
+                    // warns that "fake '<200ms' claims get caught" — and its
+                    // results table still reads _tbd_.
+                    //
+                    // A number in schema.org data is a claim made to search
+                    // engines and AI crawlers. Describing the architecture is
+                    // true and needs no benchmark; the latency figure can come
+                    // back the day the load test produces one.
+                    "Real-time engineering learning platform with coding battles over WebSockets, horizontally scaled with a Redis pub/sub adapter",
                   url: "https://eduscale.vercel.app/",
                   codeRepository: "https://github.com/Shailesh93602/devscale",
                   programmingLanguage: ["TypeScript", "JavaScript"],


### PR DESCRIPTION
`app/layout.tsx` published this in the site's **schema.org structured data** — a claim made directly to search engines and AI crawlers:

> *"Real-time engineering learning platform with coding battles, Redis pub/sub, and **<200ms sync latency**"*

**That number was never measured.** EduScale's own `loadtest/README.md` is unambiguous about it:

> *"Produce **real, measured** latency/throughput numbers to replace unverified claims in the portfolio."*
>
> *"...Honesty here reads as senior; **fake '<200ms' claims get caught**."*

Its results table still reads `_tbd_`. **The load test was written specifically to replace this claim, and never run.**

## The fix

Describe the architecture, which is true and needs no benchmark:

> *"Real-time engineering learning platform with coding battles over WebSockets, horizontally scaled with a Redis pub/sub adapter"*

The latency figure can come back the day the load test produces one.

## One I did *not* touch

`constants/projects.ts` claims Vibe Testing ensured *"sub-200ms latency for live log streaming"*. That's **ContextQA work** — the real figure may well be known, and deleting a claim about someone's own job on their behalf isn't my call. Flagged as MANUAL item 15.

## The pattern

This is the **third** fabricated claim found on this portfolio:

1. a Redis-backed idempotency guard, for a project with no Redis
2. a blog post describing that same non-existent architecture
3. a performance number the repo's own tooling was built to replace

Each was plausible, specific, and impressive — **which is exactly why none of them were questioned.**

270 tests · build · lint · format clean.