### PR TITLE
feat(stats): refresh the statistics snapshot weekly, and refuse to write a bad one

### DIFF
--- a/.github/workflows/refresh-stats.yml
+++ b/.github/workflows/refresh-stats.yml
@@ -1,0 +1,53 @@
+# Statistics Snapshot Refresh
+#
+# data/statistics-snapshot.json is what /statistics serves when the live GitHub
+# and LeetCode APIs time out. Nothing regenerated it, so it had been frozen
+# since 2026-04-20 — over four months — and presented as current.
+#
+# A stale fallback is not a crisis. It is a slow one: it gets more wrong every
+# week and nothing announces it.
+#
+# Weekly rather than daily on purpose. These numbers move slowly, a commit per
+# day would be noise in the history, and every run spends GitHub API quota that
+# the /statistics page itself needs.
+
+name: Refresh Statistics Snapshot
+
+on:
+  schedule:
+    # Sundays, 06:00 UTC — well away from the 10:00/10:30 health and claim
+    # checks, so three separate failures never look like one incident.
+    - cron: "0 6 * * 0"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    name: Refresh snapshot from the live endpoint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # No install: the script uses only node builtins and fetch. A maintenance
+      # job that needs a dependency tree is one more thing that can break and
+      # stop reporting.
+      - name: Refresh snapshot
+        run: node scripts/refresh-statistics-snapshot.mjs
+
+      - name: Commit if it changed
+        run: |
+          if git diff --quiet -- data/statistics-snapshot.json; then
+            echo "No change — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/statistics-snapshot.json
+          git commit -m "chore(stats): refresh statistics snapshot"
+          git push

--- a/data/statistics-snapshot.json
+++ b/data/statistics-snapshot.json
@@ -3674,22 +3674,22 @@
     ]
   },
   "leetcode": {
-    "totalSolved": 614,
+    "totalSolved": 615,
     "totalSubmissions": [
       {
         "difficulty": "All",
-        "count": 619,
-        "submissions": 1294
+        "count": 620,
+        "submissions": 1325
       },
       {
         "difficulty": "Easy",
-        "count": 187,
-        "submissions": 480
+        "count": 186,
+        "submissions": 488
       },
       {
         "difficulty": "Medium",
-        "count": 347,
-        "submissions": 652
+        "count": 349,
+        "submissions": 675
       },
       {
         "difficulty": "Hard",
@@ -3697,102 +3697,17 @@
         "submissions": 162
       }
     ],
-    "totalQuestions": 3906,
-    "easySolved": 185,
-    "totalEasy": 938,
-    "mediumSolved": 344,
-    "totalMedium": 2044,
+    "totalQuestions": 4033,
+    "easySolved": 184,
+    "totalEasy": 961,
+    "mediumSolved": 346,
+    "totalMedium": 2105,
     "hardSolved": 85,
-    "totalHard": 924,
-    "ranking": 119025,
-    "contributionPoint": 638,
+    "totalHard": 967,
+    "ranking": 131831,
+    "contributionPoint": 666,
     "reputation": 1,
     "submissionCalendar": {
-      "1745193600": 5,
-      "1745280000": 5,
-      "1745366400": 5,
-      "1745452800": 5,
-      "1745539200": 5,
-      "1745625600": 5,
-      "1745712000": 5,
-      "1745798400": 5,
-      "1745884800": 5,
-      "1745971200": 5,
-      "1746057600": 5,
-      "1746144000": 5,
-      "1746230400": 5,
-      "1746316800": 5,
-      "1746403200": 5,
-      "1746489600": 5,
-      "1746576000": 5,
-      "1746662400": 5,
-      "1746748800": 5,
-      "1746835200": 5,
-      "1746921600": 5,
-      "1747008000": 5,
-      "1747094400": 5,
-      "1747180800": 5,
-      "1747267200": 5,
-      "1747353600": 5,
-      "1747440000": 5,
-      "1747526400": 5,
-      "1747612800": 5,
-      "1747699200": 5,
-      "1747785600": 5,
-      "1747872000": 5,
-      "1747958400": 10,
-      "1748044800": 5,
-      "1748131200": 25,
-      "1748217600": 5,
-      "1748304000": 5,
-      "1748390400": 5,
-      "1748476800": 5,
-      "1748563200": 5,
-      "1748649600": 5,
-      "1748736000": 5,
-      "1748822400": 5,
-      "1748908800": 5,
-      "1748995200": 5,
-      "1749081600": 5,
-      "1749168000": 5,
-      "1749254400": 10,
-      "1749340800": 5,
-      "1749427200": 5,
-      "1749513600": 5,
-      "1749600000": 5,
-      "1749686400": 5,
-      "1749772800": 5,
-      "1749859200": 5,
-      "1749945600": 5,
-      "1750032000": 5,
-      "1750118400": 5,
-      "1750204800": 5,
-      "1750291200": 5,
-      "1750377600": 5,
-      "1750464000": 10,
-      "1750550400": 5,
-      "1750636800": 5,
-      "1750723200": 5,
-      "1750809600": 5,
-      "1750896000": 5,
-      "1750982400": 5,
-      "1751068800": 5,
-      "1751155200": 5,
-      "1751241600": 5,
-      "1751328000": 5,
-      "1751414400": 5,
-      "1751500800": 5,
-      "1751587200": 5,
-      "1751673600": 5,
-      "1751760000": 5,
-      "1751846400": 5,
-      "1751932800": 5,
-      "1752019200": 5,
-      "1752105600": 5,
-      "1752278400": 20,
-      "1752364800": 5,
-      "1752451200": 5,
-      "1752537600": 15,
       "1761436800": 5,
       "1766275200": 5,
       "1773446400": 160,
@@ -3804,61 +3719,106 @@
       "1774051200": 60,
       "1774137600": 25,
       "1774224000": 10,
-      "1774310400": 35
+      "1774310400": 35,
+      "1785542400": 45,
+      "1785715200": 5,
+      "1786320000": 30,
+      "1786924800": 45,
+      "1787702400": 30
     },
     "recentSubmissions": [
       {
-        "title": "Valid Parentheses",
-        "titleSlug": "valid-parentheses",
-        "timestamp": "1774371192",
+        "title": "LRU Cache",
+        "titleSlug": "lru-cache",
+        "timestamp": "1787737108",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Valid Parentheses",
-        "titleSlug": "valid-parentheses",
-        "timestamp": "1774371144",
-        "statusDisplay": "Runtime Error",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "Contains Duplicate",
-        "titleSlug": "contains-duplicate",
-        "timestamp": "1774370707",
+        "title": "LRU Cache",
+        "titleSlug": "lru-cache",
+        "timestamp": "1787737046",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Contains Duplicate",
-        "titleSlug": "contains-duplicate",
-        "timestamp": "1774370667",
+        "title": "LRU Cache",
+        "titleSlug": "lru-cache",
+        "timestamp": "1787736997",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Contains Duplicate",
-        "titleSlug": "contains-duplicate",
-        "timestamp": "1774370494",
+        "title": "LRU Cache",
+        "titleSlug": "lru-cache",
+        "timestamp": "1787736792",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Best Time to Buy and Sell Stock",
-        "titleSlug": "best-time-to-buy-and-sell-stock",
-        "timestamp": "1774369803",
+        "title": "Longest Consecutive Sequence",
+        "titleSlug": "longest-consecutive-sequence",
+        "timestamp": "1787733127",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Two Sum",
-        "titleSlug": "two-sum",
-        "timestamp": "1774369625",
+        "title": "Longest Consecutive Sequence",
+        "titleSlug": "longest-consecutive-sequence",
+        "timestamp": "1787733063",
+        "statusDisplay": "Time Limit Exceeded",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "3Sum",
+        "titleSlug": "3sum",
+        "timestamp": "1786956356",
+        "statusDisplay": "Accepted",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "3Sum",
+        "titleSlug": "3sum",
+        "timestamp": "1786955963",
+        "statusDisplay": "Wrong Answer",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "3Sum",
+        "titleSlug": "3sum",
+        "timestamp": "1786955807",
+        "statusDisplay": "Wrong Answer",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "Top K Frequent Elements",
+        "titleSlug": "top-k-frequent-elements",
+        "timestamp": "1786954286",
+        "statusDisplay": "Accepted",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "Kth Largest Element in an Array",
+        "titleSlug": "kth-largest-element-in-an-array",
+        "timestamp": "1786949900",
+        "statusDisplay": "Accepted",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "Kth Largest Element in an Array",
+        "titleSlug": "kth-largest-element-in-an-array",
+        "timestamp": "1786947798",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
@@ -3866,15 +3826,7 @@
       {
         "title": "Merge Intervals",
         "titleSlug": "merge-intervals",
-        "timestamp": "1774281518",
-        "statusDisplay": "Accepted",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "Minimum Size Subarray Sum",
-        "titleSlug": "minimum-size-subarray-sum",
-        "timestamp": "1774281001",
+        "timestamp": "1786945567",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
@@ -3882,39 +3834,31 @@
       {
         "title": "Merge Intervals",
         "titleSlug": "merge-intervals",
-        "timestamp": "1774197605",
+        "timestamp": "1786945357",
+        "statusDisplay": "Wrong Answer",
+        "lang": "cpp",
+        "__typename": "SubmissionDumpNode"
+      },
+      {
+        "title": "Product of Array Except Self",
+        "titleSlug": "product-of-array-except-self",
+        "timestamp": "1786944383",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Merge Intervals",
-        "titleSlug": "merge-intervals",
-        "timestamp": "1774197371",
+        "title": "Product of Array Except Self",
+        "titleSlug": "product-of-array-except-self",
+        "timestamp": "1786378639",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Candy",
-        "titleSlug": "candy",
-        "timestamp": "1774183740",
-        "statusDisplay": "Accepted",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "Find Peak Element",
-        "titleSlug": "find-peak-element",
-        "timestamp": "1774160672",
-        "statusDisplay": "Accepted",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "Find All Numbers Disappeared in an Array",
-        "titleSlug": "find-all-numbers-disappeared-in-an-array",
-        "timestamp": "1774157487",
+        "title": "Product of Array Except Self",
+        "titleSlug": "product-of-array-except-self",
+        "timestamp": "1786375394",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
@@ -3922,61 +3866,37 @@
       {
         "title": "Longest Substring Without Repeating Characters",
         "titleSlug": "longest-substring-without-repeating-characters",
-        "timestamp": "1774102290",
+        "timestamp": "1786368978",
         "statusDisplay": "Accepted",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Minimum Size Subarray Sum",
-        "titleSlug": "minimum-size-subarray-sum",
-        "timestamp": "1774100849",
-        "statusDisplay": "Accepted",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "Partition Labels",
-        "titleSlug": "partition-labels",
-        "timestamp": "1774097148",
-        "statusDisplay": "Accepted",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "Partition Labels",
-        "titleSlug": "partition-labels",
-        "timestamp": "1774097077",
+        "title": "Longest Substring Without Repeating Characters",
+        "titleSlug": "longest-substring-without-repeating-characters",
+        "timestamp": "1786368951",
         "statusDisplay": "Wrong Answer",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       },
       {
-        "title": "Next Greater Element II",
-        "titleSlug": "next-greater-element-ii",
-        "timestamp": "1774090704",
-        "statusDisplay": "Accepted",
-        "lang": "cpp",
-        "__typename": "SubmissionDumpNode"
-      },
-      {
-        "title": "3Sum Closest",
-        "titleSlug": "3sum-closest",
-        "timestamp": "1774074455",
-        "statusDisplay": "Accepted",
+        "title": "Longest Substring Without Repeating Characters",
+        "titleSlug": "longest-substring-without-repeating-characters",
+        "timestamp": "1786368549",
+        "statusDisplay": "Wrong Answer",
         "lang": "cpp",
         "__typename": "SubmissionDumpNode"
       }
     ],
     "currentStreak": {
       "count": 0,
-      "startDate": "2026-04-20",
-      "endDate": "2026-04-20"
+      "startDate": "2026-08-29",
+      "endDate": "2026-08-29"
     },
     "longestStreak": {
-      "count": 81,
-      "startDate": "2025-04-21",
-      "endDate": "2025-07-10"
+      "count": 6,
+      "startDate": "2026-03-14",
+      "endDate": "2026-03-19"
     },
     "activeYears": [
       2022,
@@ -3985,8 +3905,8 @@
       2025,
       2026
     ],
-    "totalActiveDays": 10,
+    "totalActiveDays": 15,
     "dccBadges": []
   },
-  "lastUpdated": "2026-04-20"
+  "lastUpdated": "2026-08-29"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "check:claims": "node scripts/check-project-claims.mjs"
+    "check:claims": "node scripts/check-project-claims.mjs",
+    "refresh:stats": "node scripts/refresh-statistics-snapshot.mjs"
   },
   "dependencies": {
     "@octokit/rest": "^21.1.1",

--- a/scripts/refresh-statistics-snapshot.mjs
+++ b/scripts/refresh-statistics-snapshot.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * refresh-statistics-snapshot.mjs
+ *
+ * Refreshes data/statistics-snapshot.json from the deployed /api/statistics.
+ *
+ * WHY THIS EXISTS.
+ *
+ * The snapshot is what /statistics serves when the live GitHub and LeetCode
+ * APIs time out. Nothing regenerated it, so it had been frozen since
+ * 2026-04-20 — over four months — and its `lastUpdated` was quietly presented
+ * as current data.
+ *
+ * A stale fallback is not a crisis. It is a slow one: the longer it sits, the
+ * more wrong it gets, and nothing announces it.
+ *
+ * WHY IT FETCHES THE DEPLOYED ENDPOINT RATHER THAN CALLING THE SERVICES.
+ *
+ * The endpoint is the real code path, including its upstream timeouts and
+ * error handling. Reimplementing that here would create a second way to fetch
+ * the same data, and the two would eventually disagree — the snapshot would
+ * then be "correct" against a code path nobody runs. Fetching the endpoint also
+ * exercises it, so a broken /api/statistics fails this job rather than being
+ * discovered by a visitor.
+ *
+ * Run: node scripts/refresh-statistics-snapshot.mjs
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT = resolve(__dirname, "..", "data", "statistics-snapshot.json");
+
+const ENDPOINT =
+  process.env.STATS_ENDPOINT ??
+  "https://shaileshchaudhari.vercel.app/api/statistics";
+const TIMEOUT_MS = 45_000;
+
+/**
+ * Refuse to overwrite a good snapshot with a worse one.
+ *
+ * 🔴 THE POINT OF THIS FUNCTION. The snapshot is a FALLBACK — it is what a
+ * visitor sees precisely when the upstream APIs are having a bad day. So the
+ * moment this job is most likely to run against degraded data is the moment its
+ * output matters most.
+ *
+ * If GitHub rate-limits us, the endpoint can legitimately answer with zeros or
+ * partial data. Writing that would destroy the last known-good numbers and
+ * replace them with a page that says this person has solved 0 problems.
+ *
+ * Monotonic counters only ever go up. A large drop means the source is wrong,
+ * not that the history changed — so a drop is treated as a failed refresh
+ * rather than new data.
+ */
+function isPlausible(next, current) {
+  const problems = [];
+
+  const checks = [
+    [
+      "github.contributions",
+      next.github?.contributions,
+      current.github?.contributions,
+    ],
+    [
+      "github.repositories",
+      next.github?.repositories,
+      current.github?.repositories,
+    ],
+    [
+      "leetcode.totalSolved",
+      next.leetcode?.totalSolved,
+      current.leetcode?.totalSolved,
+    ],
+  ];
+
+  for (const [label, nextVal, currentVal] of checks) {
+    if (typeof nextVal !== "number" || Number.isNaN(nextVal)) {
+      problems.push(`${label} is missing or not a number (${nextVal})`);
+      continue;
+    }
+    if (nextVal === 0 && (currentVal ?? 0) > 0) {
+      problems.push(`${label} came back 0, was ${currentVal}`);
+      continue;
+    }
+    // A little slack: a repo can be deleted, a solve can be un-counted. A tenth
+    // of the total cannot vanish legitimately.
+    if (typeof currentVal === "number" && nextVal < currentVal * 0.9) {
+      problems.push(`${label} dropped from ${currentVal} to ${nextVal}`);
+    }
+  }
+
+  return problems;
+}
+
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+let live;
+try {
+  const res = await fetch(ENDPOINT, {
+    signal: controller.signal,
+    headers: { "User-Agent": "portfolio-stats-refresh" },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  live = await res.json();
+} catch (error) {
+  // Not a failure worth going red over — the existing snapshot is still valid,
+  // it is just a day older. Failing loudly here would train someone to ignore
+  // this job, and the next real failure with it.
+  console.warn(`⚠  Could not reach ${ENDPOINT}: ${error.message}`);
+  console.warn("   Keeping the existing snapshot. Nothing written.");
+  process.exit(0);
+} finally {
+  clearTimeout(timer);
+}
+
+const current = JSON.parse(readFileSync(SNAPSHOT, "utf8"));
+const problems = isPlausible(live, current);
+
+if (problems.length > 0) {
+  console.error("✗ Refusing to write an implausible snapshot:");
+  for (const p of problems) console.error(`   • ${p}`);
+  console.error(
+    "\n  The upstream APIs are likely degraded or rate-limited. The existing\n" +
+      "  snapshot is kept — it is stale, which is far better than wrong."
+  );
+  process.exit(1);
+}
+
+const next = {
+  ...live,
+  lastUpdated: new Date().toISOString().slice(0, 10),
+};
+
+const before = JSON.stringify(current);
+const after = JSON.stringify(next);
+
+// Compare ignoring lastUpdated, so an unchanged day produces no commit.
+const beforeSansDate = JSON.stringify({ ...current, lastUpdated: null });
+const afterSansDate = JSON.stringify({ ...next, lastUpdated: null });
+
+if (beforeSansDate === afterSansDate) {
+  console.log(
+    "✓ Statistics unchanged — snapshot left alone (no empty commit)."
+  );
+  process.exit(0);
+}
+
+writeFileSync(SNAPSHOT, JSON.stringify(next, null, 2) + "\n");
+
+console.log("✓ Snapshot refreshed");
+console.log(
+  `   github.contributions  ${current.github?.contributions} → ${next.github?.contributions}`
+);
+console.log(
+  `   leetcode.totalSolved  ${current.leetcode?.totalSolved} → ${next.leetcode?.totalSolved}`
+);
+console.log(
+  `   lastUpdated           ${current.lastUpdated} → ${next.lastUpdated}`
+);
+(void before, void after);


### PR DESCRIPTION
`data/statistics-snapshot.json` is what `/statistics` serves when the live GitHub and LeetCode APIs time out. **Nothing regenerated it.** It had been frozen since **2026-04-20** — over four months — with its `lastUpdated` presented as current.

A stale fallback isn't a crisis. It's a slow one: it gets more wrong every week and nothing announces it.

## The guard is the point, not the fetch

The snapshot is a **fallback** — it's what a visitor sees *precisely when the upstream APIs are having a bad day*. So **the moment this job is most likely to run against degraded data is the moment its output matters most.**

If GitHub rate-limits us, the endpoint can legitimately answer with zeros or partial data. Writing that would destroy the last known-good numbers and replace them with a page claiming this person has solved **0 problems** and has **0 repos**.

So it refuses any refresh where a monotonic counter came back zero or dropped by more than a tenth. Those counters only go up — **a large drop means the source is wrong, not that history changed.**

**Verified both paths against a fake endpoint:**

```
all zeros       ->  refused, naming each counter and its previous value
35% drop        ->  refused: "leetcode.totalSolved dropped from 615 to 400"
unchanged data  ->  no write, so the weekly job produces no empty commit
```

## Why it fetches the deployed endpoint

`/api/statistics` is the **real code path**, including its upstream timeouts and error handling. Reimplementing that here would create a second way to fetch the same data, and the two would eventually disagree — the snapshot would then be "correct" against a code path nobody runs. Fetching it also **exercises** it, so a broken endpoint fails this job rather than being found by a visitor.

An unreachable endpoint **exits 0, not 1**. The existing snapshot is still valid, just a week older — going red over it would train someone to ignore this job, and the next real failure with it.

**Weekly, not daily:** these numbers move slowly, a daily commit would be noise, and every run spends GitHub quota that `/statistics` itself needs.

First run: `leetcode.totalSolved` 614 → 615, `lastUpdated` 2026-04-20 → **2026-08-29**.