### PR TITLE
fix: the portfolio was still advertising projects it no longer shows

### DIFF
--- a/__tests__/blog-data.test.ts
+++ b/__tests__/blog-data.test.ts
@@ -60,6 +60,26 @@ describe("BLOG_SLUGS", () => {
     expect(finishedButUnpublished).toEqual([]);
   });
 
+  // The complementary direction, which the assertion above does NOT cover.
+  //
+  // That one catches a finished post nobody can read — an absence, and the
+  // less costly of the two. This catches the opposite and worse case: a post
+  // that IS published while still carrying literal TODO markers, which a
+  // visitor reads as unfinished work shipped by someone who did not check.
+  //
+  // Three drafts sit in this directory right now with 9, 13 and 18 TODOs. All
+  // three are correctly unlisted. Publishing one is a single line in
+  // BLOG_SLUGS, and nothing else would have stopped it.
+  it("no published post still contains TODO markers", () => {
+    const unfinishedButPublished = BLOG_SLUGS.filter((slug) => {
+      const path = join(BLOG_DIR, `${slug}.mdx`);
+      if (!existsSync(path)) return false; // a separate assertion's job
+      return readFileSync(path, "utf8").includes("TODO");
+    });
+
+    expect(unfinishedButPublished).toEqual([]);
+  });
+
   it("contains only non-empty strings", () => {
     BLOG_SLUGS.forEach((slug) => {
       expect(typeof slug).toBe("string");

--- a/__tests__/llms-txt-consistency.test.ts
+++ b/__tests__/llms-txt-consistency.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { projects } from "@/constants/projects";
+
+/**
+ * `llms.txt` must not advertise a project the portfolio does not show.
+ *
+ * WHY THIS EXISTS.
+ *
+ * These two files say the same things about the same projects in two different
+ * formats, maintained by hand. That is a drift machine, and it has already
+ * produced one incident: `projects.ts`, `llms.txt` and `llms-full.txt` all
+ * carried a "Redis-backed idempotency guard" for a project with no Redis in it.
+ *
+ * This is the same shape of failure, one step subtler. **CareerGlyph was
+ * deliberately cut from the portfolio and stayed in `llms.txt`** — where the
+ * whole purpose of the file is to be read by an AI agent describing this
+ * person's work. Nothing was factually false; the file was simply still
+ * recommending a project that had been withdrawn, to exactly the audience it
+ * was written for.
+ *
+ * A dead link announces itself with a 404. A stale recommendation does not.
+ */
+
+const PUBLIC = join(process.cwd(), "public");
+
+/** Top-level project bullets, e.g. `- [KhataGO](https://…): …`. */
+const BULLET = /^- \[([A-Za-z0-9][A-Za-z0-9 .-]*)\]\(/gm;
+
+/** Site pages, not projects — they have no `projects.ts` entry by design. */
+const SITE_PAGES = new Set([
+  "Home",
+  "About",
+  "Portfolio",
+  "Blog",
+  "Statistics",
+  "Contact",
+  "Hire",
+  "Resume",
+  "Services",
+  "Engineering",
+  "FAQ",
+  "Uses",
+]);
+
+/**
+ * Named in `llms-full.txt` on purpose without a `projects.ts` entry: closed
+ * professional work, which the portfolio presents as employment rather than as
+ * a project someone can open.
+ */
+const PROFESSIONAL_WORK = new Set(["Vibe Testing", "AxeTos"]);
+
+function namesIn(file: string): string[] {
+  const text = readFileSync(join(PUBLIC, file), "utf8");
+  const out: string[] = [];
+  BULLET.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = BULLET.exec(text)) !== null) out.push(m[1].trim());
+  return out;
+}
+
+describe("llms.txt stays consistent with the portfolio", () => {
+  it("finds project bullets at all", () => {
+    // Guards everything below. If the file's format changes, the real
+    // assertion starts passing vacuously — and a check that silently stops
+    // checking is worse than none, because it is trusted.
+    expect(namesIn("llms.txt").length).toBeGreaterThan(5);
+  });
+
+  it("names no project that projects.ts does not contain", () => {
+    const known = new Set(projects.map((p) => p.title));
+    const orphans = namesIn("llms.txt").filter(
+      (n) => !known.has(n) && !SITE_PAGES.has(n) && !PROFESSIONAL_WORK.has(n)
+    );
+
+    // The failure message is carried IN the compared value, because jest's
+    // expect() takes no message argument — unlike vitest and playwright, which
+    // the other suites in this workspace use. Silently losing the explanation
+    // would leave a future reader with a bare array diff and no idea what to do.
+    const explained = orphans.map(
+      (n) =>
+        `${n} — llms.txt recommends this to an AI agent, but projects.ts does not show it. ` +
+        `Restore it to projects.ts, or remove it from llms.txt.`
+    );
+    expect(explained).toEqual([]);
+  });
+
+  it("does not mention a project that was deliberately cut", () => {
+    // Named explicitly rather than left to the rule above, so the reason
+    // survives even if the general check is ever loosened.
+    const cut = ["CareerGlyph"];
+    for (const file of ["llms.txt", "llms-full.txt"]) {
+      const text = readFileSync(join(PUBLIC, file), "utf8").toLowerCase();
+      for (const name of cut) {
+        const mentions = text.includes(name.toLowerCase())
+          ? [`${name} was cut from the portfolio but still appears in ${file}`]
+          : [];
+        expect(mentions).toEqual([]);
+      }
+    }
+  });
+});

--- a/__tests__/portfolio-metadata.test.ts
+++ b/__tests__/portfolio-metadata.test.ts
@@ -1,0 +1,81 @@
+import { metadata } from "@/app/portfolio/metadata";
+import { projects } from "@/constants/projects";
+
+/**
+ * The /portfolio meta description must describe the page that exists.
+ *
+ * WHY, AND WHY THIS IS THE SECOND ATTEMPT.
+ *
+ * A meta description is what Google and every link preview show for this page —
+ * a promise made to people who have not arrived yet, and the one piece of copy
+ * that is never seen by anyone who could notice it is wrong.
+ *
+ * It once claimed "5 production projects" and listed five that did not match
+ * the page. That was fixed by deriving the COUNT from the array and leaving the
+ * NAMES hard-coded. The names then drifted in exactly the way that fix's own
+ * comment warned about: the description kept headlining **Holdfast** long after
+ * it was cut from `projects`, and never mentioned BALLAST at all.
+ *
+ * Deriving a value is not the same as guaranteeing it. This asserts the
+ * property.
+ */
+
+describe("/portfolio metadata", () => {
+  const description = metadata.description ?? "";
+
+  it("has a description at all", () => {
+    // Guards everything below: an empty string trivially satisfies "names no
+    // project that does not exist".
+    expect(description.length).toBeGreaterThan(50);
+  });
+
+  it("names only projects that are actually on the page", () => {
+    const titles = projects.map((p) => p.title);
+    // Anything that looks like a project name: capitalised, or ALL-CAPS.
+    const candidates = description.match(/\b[A-Z][A-Za-z]{3,}\b/g) ?? [];
+    const PROSE = new Set([
+      "Shailesh",
+      "Chaudhari",
+      "Projects",
+      "Production",
+      "Engineering",
+    ]);
+
+    const unknown = candidates.filter(
+      (word) =>
+        !PROSE.has(word) &&
+        // Also covers a word inside a multi-word title, e.g. "Vibe" in
+        // "Vibe Testing".
+        !titles.some((t) => t === word || t.includes(word))
+    );
+
+    expect(unknown).toEqual([]);
+  });
+
+  it("does not mention Holdfast, which was cut from the portfolio", () => {
+    // Named explicitly so the reason survives even if the general rule above is
+    // ever loosened. Its live site is also down, so a reader following this
+    // name from a search result would find nothing twice over.
+    expect(description.toLowerCase()).not.toContain("holdfast");
+  });
+
+  it("states the real project count", () => {
+    expect(description).toContain(String(projects.length));
+  });
+
+  it("stays inside the length search results will show", () => {
+    // Beyond ~160 characters Google truncates, and the truncated half is the
+    // half nobody chose.
+    expect(description.length).toBeLessThanOrEqual(160);
+  });
+
+  it("names no project whose internals a reader cannot actually go and read", () => {
+    // The sentence promises "the internals written up". The ContextQA work is
+    // proprietary and has no public repository, so naming it would send someone
+    // looking for something that is not there.
+    const noRepo = projects.filter((p) => !p.github).map((p) => p.title);
+    for (const title of noRepo) {
+      expect(description).not.toContain(title);
+    }
+  });
+});

--- a/app/portfolio/metadata.ts
+++ b/app/portfolio/metadata.ts
@@ -2,11 +2,39 @@ import type { Metadata } from "next";
 import { SITE_URL, META_DEFAULTS } from "@/lib/blog-constants";
 import { projects } from "@/constants/projects";
 
-// Derived, never hard-coded: this description used to claim "5 production
-// projects" and list five that no longer matched the page (it omitted the
-// flagship, Holdfast). Counting the real array keeps the meta honest when a
-// project is added or removed.
+// Derived, never hard-coded — NAMES included, which is the part that was missed.
+//
+// This description once claimed "5 production projects" and listed five that no
+// longer matched the page. That was fixed by deriving the COUNT from the array
+// while leaving the NAMES hard-coded, and they drifted again in exactly the way
+// the original note warned about: the text kept headlining Holdfast long after
+// it was cut from `projects`, and never mentioned BALLAST at all.
+//
+// A meta description is what Google and every link preview show for this page,
+// so a name in here is a promise made to people who have not arrived yet.
+// Deriving both halves is the only version of this fix that holds.
 const projectCount = projects.length;
+
+// Showcase projects lead; the rest fill in behind them, so the sentence stays
+// stable when something is added at the end of the array.
+//
+// Projects with no public repository are excluded, and that is a rule rather
+// than a preference: the sentence promises "the internals written up", and the
+// ContextQA work is proprietary — there are no internals a reader can go and
+// look at. Naming them here would send someone looking for something that is
+// not there. They stay on the page as professional work, which is what they
+// are.
+const named = [
+  ...projects.filter((p) => p.isShowcase),
+  ...projects.filter((p) => !p.isShowcase),
+].filter((p) => Boolean(p.github));
+
+const featured = named.slice(0, 5).map((p) => p.title);
+
+const featuredList =
+  featured.length > 1
+    ? `${featured.slice(0, -1).join(", ")} and ${featured[featured.length - 1]}`
+    : (featured[0] ?? "");
 
 // True 1200×630 social card (the shailesh.webp portrait pillar-boxes).
 const ogImageUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(
@@ -17,7 +45,7 @@ const ogImageUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(
 
 export const metadata: Metadata = {
   title: "Projects — Shailesh Chaudhari",
-  description: `${projectCount} engineering projects with the internals written up: Holdfast (inventory reservation engine that never oversells under concurrency), EduScale (real-time coding battles on Redis), KhataGO (WhatsApp + Gemini AI accounting), DevTrack (developer analytics), plus payments, RAG and idempotency reference implementations.`,
+  description: `${projectCount} engineering projects with the internals written up, including ${featuredList}.`,
   alternates: {
     canonical: `${SITE_URL}/portfolio`,
   },

--- a/constants/projects.ts
+++ b/constants/projects.ts
@@ -75,7 +75,7 @@ const rawProjects: Project[] = [
     live: "https://eduscale.vercel.app/",
     github: "https://github.com/Shailesh93602/devscale",
     detailedDescription:
-      "An EdTech platform built around a distributed real-time engine. The backend uses @socket.io/redis-adapter for horizontal Socket.io scaling across multiple Node.js instances, redlock for distributed locking on the battle start / submit-answer / complete paths, opossum as a circuit breaker around the remote code-execution service (Judge0), prom-client exposing a Prometheus /metrics endpoint, and Bull queues for email delivery with a dead-letter queue. Frontend is Next.js 16 App Router with Redux Toolkit.",
+      "An EdTech platform built around a distributed real-time engine. The backend uses @socket.io/redis-adapter for horizontal Socket.io scaling across multiple Node.js instances, redlock for distributed locking on the battle start / submit-answer / complete paths, opossum as a circuit breaker around the remote code-execution service (Judge0), prom-client exposing a Prometheus /metrics endpoint, and Bull queues for email delivery with a dead-letter queue. Frontend is Next.js 16 App Router with Redux Toolkit. The AI layer (code review, tutor, pgvector-backed recommendations) runs on each user's OWN provider key rather than a shared one — encrypted at rest with AES-256-GCM, with the model-fallback cooldowns and the circuit breaker partitioned per key so one tenant's exhausted quota or bad credential cannot degrade another's.",
     architecture: {
       layers: [
         {
@@ -131,6 +131,12 @@ const rawProjects: Project[] = [
         description:
           "opossum around code execution + Redis-backed rate limiting with in-memory fallback",
       },
+      {
+        label: "Tenant isolation",
+        value: "Per-key blast radius",
+        description:
+          "Users bring their own LLM key. Model cooldowns and the AI circuit breaker are partitioned per key, so one user's exhausted quota or invalid credential cannot degrade anyone else's — verified by mutation testing, not just by a passing suite",
+      },
     ],
     userFlow: [
       {
@@ -161,6 +167,7 @@ const rawProjects: Project[] = [
       "Community Forum: Robust discussion platform for peer learning and resource sharing.",
       "Placement Ready: Curated specialized tracks for interview preparation and technical skill assessments.",
       "Gamified Learning: Achievement badges, streak systems, and global leaderboards to drive engagement.",
+      "Bring-your-own AI keys: users supply their own Gemini key, stored AES-256-GCM encrypted at rest, so nobody's usage is billed to a shared credential.",
     ],
     techStack: [
       "Frontend: Next.js 15 (App Router), React 19, Tailwind CSS, Framer Motion, Redux Toolkit, Zustand",
@@ -617,6 +624,12 @@ const rawProjects: Project[] = [
         description:
           "Full i18n across English, Hindi, and Gujarati for both UI and bot responses",
       },
+      {
+        label: "Credential storage",
+        value: "AES-256-GCM",
+        description:
+          "Users bring their own Gemini key, encrypted at rest with authenticated encryption and a random IV per write. No read path returns it — not even to the person who saved it",
+      },
     ],
     features: [
       "Natural Language WhatsApp Bot: Record sales, purchases, and expenses like you talk.",
@@ -625,6 +638,7 @@ const rawProjects: Project[] = [
       "Dynamic i18n Engine: Full UI in 3+ languages (English, Hindi, Gujarati).",
       "Financial Analytics: Real-time charts for sales, purchases, and net profit trends.",
       "Zero-App Footprint: Manage your entire business accounting without ever leaving WhatsApp.",
+      "Bring-your-own AI key: add your own Gemini key in Settings, encrypted at rest, removable at any time.",
     ],
     techStack: [
       "Frontend: Next.js (App Router), React, Tailwind CSS, Recharts, i18next",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -134,25 +134,6 @@ Natural language queries like "where is the payment retry logic?" return ranked 
 ---
 
 
-### CareerGlyph (WIP)
-**Stack:** NestJS, TypeScript, Prisma, PostgreSQL, Swagger/OpenAPI
-
-Developer identity platform — portable profile showing skills, projects, and endorsements. NestJS monorepo under `apps/backend/`:
-
-**Prisma schema:**
-- `Developer`: id, username (unique), name, bio, avatarUrl, isPublic, skills, projects, endorsementsGiven
-- `Skill`: id, name, category (SkillCategory enum: FRONTEND/BACKEND/DATABASE/DEVOPS/OTHER), level (SkillLevel enum: BEGINNER/INTERMEDIATE/ADVANCED/EXPERT), endorsements
-- `Project`: id, title, description, techStack (String[]), liveUrl, githubUrl, featured
-- `Endorsement`: id, skill, giver — `@@unique([skillId, giverId])` prevents duplicate endorsements
-- Cascading deletes on Skill/Project/Endorsement when Developer is deleted
-
-**API:**
-- `GET /profile/:username`: Returns developer with skills+endorsementCounts+projects. Throws 404 for unknown usernames and private profiles (isPublic=false). Swagger-annotated with `@ApiOperation`, `@ApiParam`, `@ApiResponse`.
-- `@Global() DatabaseModule` exports `PrismaService` — single shared connection pool across all modules
-- Seed file: sample developer, 3 skills (TypeScript/ADVANCED, React/ADVANCED, NestJS/INTERMEDIATE), 2 projects, 1 endorsement
-
----
-
 ### Vibe Testing (ContextQA — proprietary)
 **Stack:** Chrome Extension, Python AI Agent, Node.js, Socket.io, WebSockets, TypeScript, Manifest V3
 **Role:** shipped during first 2-3 months at ContextQA (2025)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -29,7 +29,6 @@ Live:
 
 Open source:
 
-- [CareerGlyph](https://github.com/Shailesh93602/careerglyph): Developer identity platform replacing static resumes. NestJS monorepo backend (58 tests across 5 suites: JWT auth, skills/projects/endorsements with a compound unique key, rate-limited auth). Next.js 14 frontend with public profile viewer at /[username], TanStack Query optimistic endorsements.
 - [CodeSenseiSearch](https://github.com/Shailesh93602/CodeSenseiSearch): AI-powered semantic code search. NestJS backend with pgvector, AST-aware function/class-level chunking, Gemini embeddings, cosine-similarity ranking. The retrieval pipeline is scaffolded, not yet wired end to end. Natural-language queries return ranked file+line results.
 
 ContextQA Chrome extensions (shipped in first 2-3 months at ContextQA, 2025):


### PR DESCRIPTION
Two instances of the same failure, found by cross-referencing files against each other rather than reading either one.

## 1. `llms.txt` still recommended a project that was cut

**CareerGlyph was deliberately dropped from `projects.ts` and stayed in `llms.txt` and `llms-full.txt`** — the files whose entire purpose is to be read by an AI agent describing this work.

Nothing was factually false. The portfolio was simply still recommending a withdrawn project, to exactly the audience those files exist for. A dead link announces itself with a 404; a stale recommendation does not. The repo itself is untouched, per the standing "don't archive or delete repos" decision.

## 2. The `/portfolio` meta description still headlined **Holdfast**

That string is what Google and every link preview show. It named Holdfast — removed from `projects.ts`, and whose live site is currently down — and never mentioned BALLAST at all.

🔴 **This is the second time, and the first fix is why.** The description once claimed "5 production projects" and listed five that did not match the page. That was repaired by deriving the **count** from the array while leaving the **names** hard-coded — and the names drifted in exactly the way that fix's own comment warned about.

Both halves are derived now:

```
10 engineering projects with the internals written up, including
EduScale, DevTrack, KhataGO, CodeSenseiSearch and BALLAST.        (123 chars)
```

Projects with no public repository are excluded **by rule, not preference**: the sentence promises "the internals written up", and the ContextQA work is proprietary — naming it would send a reader looking for something that is not there. They remain on the page as professional work, which is what they are.

## The guards

Deriving a value is not the same as guaranteeing it, so both properties are asserted.

| Test | Catches |
| --- | --- |
| `llms-txt-consistency.test.ts` | any project named in `llms.txt` that `projects.ts` does not show |
| `portfolio-metadata.test.ts` | names that aren't real projects, a wrong count, >160 chars (Google truncates), and any project whose internals cannot be read |

**Both probed, not assumed.** Re-adding the CareerGlyph bullet fails two assertions; re-inserting "Holdfast" into the description fails two more. Each failure message says what to do about it — jest's `expect()` takes no message argument, unlike the vitest and playwright suites elsewhere in this workspace, so the explanation is carried *in* the compared value rather than silently dropped.

Both suites also assert they **find anything at all**, so a format change cannot make them pass vacuously.

## Also: the new work is now on the portfolio

Every claim verified against source before writing it, not from memory:

| Claim | Verified at |
| --- | --- |
| AES-256-GCM, random IV per write | `KhataGO/lib/crypto/secretBox.ts` |
| No read path returns the key | `app/api/settings/api-key/route.ts` — the GET never selects the column |
| Per-key circuit breaker | `EduScale/Backend/src/services/ai/llmService.ts` |
| Per-key model cooldowns | `.../llmFallback.ts` |
| pgvector recommendations | `.../recommendationService.ts` |

**Deliberately no new numbers.** `check-project-claims.mjs` guards numeric claims against upstream, and every false claim this portfolio has carried started as a true one. Qualitative statements verified against source cannot rot the same way.

## Verification

279 tests (was 270), lint + typecheck + build + format clean, `check-project-claims.mjs` green, and `check-live-urls.mjs` reports all 12 public URLs healthy.