### PR TITLE
fix(a11y): the contribution heatmap could not be scrolled by keyboard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,23 @@
     // General rules
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-debugger": "error",
-    "no-unused-vars": "error"
+    "no-unused-vars": "error",
+
+    // A scrollable region legitimately takes tabIndex.
+    //
+    // The default rule allows only role="tabpanel". But WCAG 2.1.1 requires a
+    // scroll container be reachable from the keyboard — a keyboard-only user
+    // can otherwise see that content is cut off and has no way to move it —
+    // and axe reports the absence as `scrollable-region-focusable`. The two
+    // tools disagree, and axe is the one describing a real barrier.
+    //
+    // `roles` is the rule's own supported escape hatch, so this states the
+    // exception rather than suppressing the rule. It stays narrow: `region`
+    // only, not non-interactive elements in general.
+    "jsx-a11y/no-noninteractive-tabindex": [
+      "error",
+      { "roles": ["tabpanel", "region"] }
+    ]
   },
   "settings": {
     "react": {

--- a/components/github-contribution-heatmap.tsx
+++ b/components/github-contribution-heatmap.tsx
@@ -72,7 +72,27 @@ export function GitHubContributionHeatmap({
           </p>
         </div>
         <CardContent className="p-0">
-          <div className="overflow-x-auto pb-2">
+          {/*
+            tabIndex + role + label, because this scrolls.
+            A region that scrolls but holds no focusable children cannot be
+            reached by keyboard at all — a keyboard-only user can see that the
+            heatmap is cut off and has no way to move it. That is WCAG 2.1.1
+            (Keyboard), and axe reports it as `scrollable-region-focusable`.
+            Making it focusable is the remedy axe itself recommends: arrow keys
+            then scroll it like any other focusable scroll container.
+
+            It only overflows at narrow widths, which is why the desktop-only
+            run missed it and CI's mobile project did not.
+
+            The label matters as much as the tabIndex: landing on an unnamed
+            focus stop announces nothing, which trades one barrier for another.
+          */}
+          <div
+            className="overflow-x-auto pb-2"
+            tabIndex={0}
+            role="region"
+            aria-label="GitHub contribution heatmap, scrollable horizontally"
+          >
             <div className="flex flex-col gap-2">
               <div className="mb-2 flex justify-between text-xs font-medium text-foreground">
                 <span>Less</span>


### PR DESCRIPTION
## The a11y job I added in #33 has been failing on `main`, and I didn't check

`/statistics` fails `scrollable-region-focusable` in both themes. It is a **real WCAG 2.1.1 (Keyboard) violation**, not the animation artifact that has been the story elsewhere today.

The contribution heatmap sits in an `overflow-x-auto` div containing no focusable children. A keyboard-only user can see the content is cut off and **has no way to move it**.

`tabIndex` + `role` + `aria-label` is the remedy axe itself names — arrow keys then scroll it like any other focusable container. The label matters as much as the tabIndex: landing on an unnamed focus stop trades one barrier for another.

## Why I missed it and CI didn't

**It only overflows at narrow widths.** I ran 44 tests locally; CI runs **88**, because it includes the mobile project. I reported "44 passed" as though it were the whole suite.

Same shape as the EduScale mistake an hour ago: I measured the environment least likely to expose the problem, then reported the result as if it settled the question.

## Two a11y tools disagreed

`eslint-plugin-jsx-a11y`'s `no-noninteractive-tabindex` rejects `tabIndex` on a non-interactive element. That is good general advice — and wrong here, because a **scrollable** region is interactive in the only sense that matters: it holds state a user needs to change, and WCAG requires that be reachable.

axe is describing a real barrier, so axe wins. But expressed through **the rule's own `roles` option** rather than an inline suppression, so the exception is stated rather than silenced — and kept narrow (`region` only, not non-interactive elements generally).

Worth recording for next time: **`eslint-disable-next-line` inside JSX anchors to the line the comment *starts* on**, so a long explanatory block cannot carry a directive for an attribute several lines below. That cost two attempts before configuring the rule properly, which was the better answer anyway.

## Verification

280 unit tests, lint clean (**0 errors**, down from 1), typecheck clean.

The Playwright a11y suite is the authoritative check here and runs in CI — which is precisely the environment that caught this in the first place.