### PR TITLE
chore: BALLAST test count 182 → 186

### DIFF
--- a/constants/projects.ts
+++ b/constants/projects.ts
@@ -763,7 +763,7 @@ const rawProjects: Project[] = [
     techStack: [
       "Language: TypeScript (ESM, strict)",
       "Dependencies: none at runtime — typescript, eslint, prettier and vitest only",
-      "Tests: Vitest (182)",
+      "Tests: Vitest (186)",
       "Verification: invariants + reference oracle + mutation testing + shrinker",
     ],
     problem:


### PR DESCRIPTION
The upstream grew four tests — the flash sale now runs against a **real Postgres** (`ballast/src/tierb/flashSaleReal.ts`): 200 concurrent buyers, 5 units, judged by counting rows. The naive strategy sold 200 of 5 units; the correct two sold exactly 5, the optimistic one paying 748 retries for it.

This is exactly the drift the daily claim-check exists to catch. Ballast's own README guard caught it first (README 182 vs suite 186 → red), and updating `projects.ts` in the same push-batch as the upstream keeps the daily check green rather than proving it works the noisy way.

**Resume note:** `resume-lines.md` still says 182 — re-verify numbers against `npm test` output at paste time, never copy them from a doc, including this one.