### PR TITLE
Fix /engineering links that 404 for every visitor (private repos)

### DIFF
--- a/app/engineering/page.tsx
+++ b/app/engineering/page.tsx
@@ -57,9 +57,11 @@ interface Finding {
 }
 
 /**
- * Every entry links to the write-up in the repo it came from. Nothing here is
- * a claim the reader has to take on trust — the point of the page is that it is
- * all checkable.
+ * Every entry links to a PUBLIC write-up — the repo's FINDINGS.md when the
+ * repo is public, the blog post telling the same story when it is not
+ * (KhataGO is currently private). The point of the page is that it is all
+ * checkable; a link that 404s for a visitor defeats it. When KhataGO goes
+ * public, point its entries back at its FINDINGS.md.
  */
 const findings: readonly Finding[] = [
   {
@@ -70,7 +72,7 @@ const findings: readonly Finding[] = [
     lesson:
       "A test that reaches through a framework's rendered output is coupled to that framework's rendering decisions, and it fails silently by matching nothing.",
     where: "KhataGO",
-    href: "https://github.com/Shailesh93602/KhataGO/blob/main/FINDINGS.md",
+    href: "/blog/a-passing-test-only-proves-the-test-passes",
   },
   {
     title: "A lock with no way out of it",
@@ -80,7 +82,7 @@ const findings: readonly Finding[] = [
     lesson:
       "Mutual exclusion and liveness are different properties. Passing tests for the first say nothing about the second — a lock without an expiry is a deadlock waiting for a crash.",
     where: "KhataGO",
-    href: "https://github.com/Shailesh93602/KhataGO/blob/main/FINDINGS.md",
+    href: "/blog/khatago-webhook-deduplication-receipt-pipeline",
   },
   {
     title: "An idempotency guard that was not one",
@@ -90,7 +92,7 @@ const findings: readonly Finding[] = [
     lesson:
       "Code that copes with a condition is evidence someone knew it could happen. Prevent it at the constraint, and let the read be a fast path.",
     where: "EduScale",
-    href: "https://github.com/Shailesh93602/EduScale/blob/main/FINDINGS.md",
+    href: "https://github.com/Shailesh93602/DevScale/blob/main/FINDINGS.md",
   },
   {
     title: "A safety guard whose allow-list matched production",
@@ -100,7 +102,7 @@ const findings: readonly Finding[] = [
     lesson:
       "An allow-list whose most permissive entry matches the thing you are guarding against is not an allow-list. This one is mine, found the same week I wrote it.",
     where: "EduScale",
-    href: "https://github.com/Shailesh93602/EduScale/blob/main/FINDINGS.md",
+    href: "https://github.com/Shailesh93602/DevScale/blob/main/FINDINGS.md",
   },
   {
     title: "Migrations that never ran",
@@ -110,7 +112,7 @@ const findings: readonly Finding[] = [
     lesson:
       "Before making every deploy run migrations I checked what production's migration table actually contained, and found rows with no matching files. Reproducing that drift locally first is the only reason the fix did not break every deploy.",
     where: "KhataGO + EduScale",
-    href: "https://github.com/Shailesh93602/KhataGO/blob/main/FINDINGS.md",
+    href: "https://github.com/Shailesh93602/DevScale/blob/main/FINDINGS.md",
   },
   {
     title: "Six bugs, half of them in the checker",
@@ -144,9 +146,9 @@ export default function EngineeringPage() {
 
         <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
           These are real defects from my own production code. Several are
-          mistakes I made myself and found later. Every one links to the
-          write-up in the repo it came from, so none of it has to be taken on
-          trust.
+          mistakes I made myself and found later. Every one links to a public
+          write-up — the repo it came from, or the blog post that tells the
+          full story — so none of it has to be taken on trust.
         </p>
 
         <div className="mt-12 space-y-10">

--- a/content/blog/a-passing-test-only-proves-the-test-passes.mdx
+++ b/content/blog/a-passing-test-only-proves-the-test-passes.mdx
@@ -124,4 +124,4 @@ You do not need to find the bug. You need to notice that **the failure would be 
 
 ---
 
-_Each of these is written up with the full diagnosis in the repositories they came from — [KhataGO](https://github.com/Shailesh93602/KhataGO/blob/main/FINDINGS.md), [EduScale](https://github.com/Shailesh93602/EduScale/blob/main/FINDINGS.md), and [BALLAST's ledger](https://github.com/Shailesh93602/ballast/blob/main/docs/LEDGER.md), where three of eight findings turned out to be in the checker rather than the system under test._
+_Each of these is written up with the full diagnosis where it can be read publicly: [EduScale's FINDINGS.md](https://github.com/Shailesh93602/DevScale/blob/main/FINDINGS.md), [BALLAST's ledger](https://github.com/Shailesh93602/ballast/blob/main/docs/LEDGER.md) — where three of eight findings turned out to be in the checker rather than the system under test — and the KhataGO cases in this post and [the webhook write-up](/blog/khatago-webhook-deduplication-receipt-pipeline) (its repository is currently private)._

--- a/content/blog/khatago-webhook-deduplication-receipt-pipeline.mdx
+++ b/content/blog/khatago-webhook-deduplication-receipt-pipeline.mdx
@@ -165,4 +165,4 @@ That test lives in an integration suite against a real Postgres, because a claim
 
 ---
 
-_KhataGO is a WhatsApp-first bookkeeping platform for Indian MSMEs. The bugs above, and several more, are written up in its [`FINDINGS.md`](https://github.com/Shailesh93602/KhataGO/blob/main/FINDINGS.md) — including one where an i18n change silently broke a test that had been asserting nothing for months._
+_KhataGO is a WhatsApp-first bookkeeping platform for Indian MSMEs. The bugs above, and several more, are written up on [How I verify](/engineering) — including one where an i18n change silently broke a test that had been asserting nothing for months (its repository is currently private)._


### PR DESCRIPTION
The page's pitch is *'none of it has to be taken on trust'* — but 5 of 6 entry links pointed into **private** repos (KhataGO and EduScale both), so every visitor got a 404 exactly where the page claims checkability.

- EduScale entries → the public **DevScale** mirror's `FINDINGS.md` (verified present, 8.4KB)
- KhataGO entries → the public blog posts telling the same stories (verified the lock-expiry post covers the claim/staleness/dead-letter design in detail)
- The mixed KhataGO+EduScale entry → DevScale
- Page copy + code comment updated so the promise stays literally true, with a note to revert KhataGO links to its FINDINGS.md the day the repo goes public
- Same fix in two blog footers

Gate: lint ✓ tsc ✓ 279 tests ✓ format ✓ build ✓