### PR TITLE
Fix prettier drift #42 introduced — main CI is red

### DIFF
--- a/app/engineering/page.tsx
+++ b/app/engineering/page.tsx
@@ -147,8 +147,8 @@ export default function EngineeringPage() {
         <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
           These are real defects from my own production code. Several are
           mistakes I made myself and found later. Every one links to a public
-          write-up — the repo it came from, or the blog post that tells the
-          full story — so none of it has to be taken on trust.
+          write-up — the repo it came from, or the blog post that tells the full
+          story — so none of it has to be taken on trust.
         </p>
 
         <div className="mt-12 space-y-10">


### PR DESCRIPTION
My #42 edit to `app/engineering/page.tsx` was applied AFTER the format gate ran, so main's last two CI runs fail format:check on this one file. Whitespace-only fix; full gate re-run: lint ✓ tsc ✓ 287 tests ✓ format ✓ build ✓. After merge, #41's failed check gets re-run (it fails on the merge-preview containing main's dirty file).