### PR TITLE
BALLAST claims track upstream: 197 tests, nine findings (L9)

### DIFF
--- a/constants/projects.ts
+++ b/constants/projects.ts
@@ -763,7 +763,7 @@ const rawProjects: Project[] = [
     techStack: [
       "Language: TypeScript (ESM, strict)",
       "Dependencies: none at runtime — typescript, eslint, prettier and vitest only",
-      "Tests: Vitest (186)",
+      "Tests: Vitest (197)",
       "Verification: invariants + reference oracle + mutation testing + shrinker",
     ],
     problem:

--- a/content/blog/a-passing-test-only-proves-the-test-passes.mdx
+++ b/content/blog/a-passing-test-only-proves-the-test-passes.mdx
@@ -124,4 +124,4 @@ You do not need to find the bug. You need to notice that **the failure would be 
 
 ---
 
-_Each of these is written up with the full diagnosis where it can be read publicly: [EduScale's FINDINGS.md](https://github.com/Shailesh93602/DevScale/blob/main/FINDINGS.md), [BALLAST's ledger](https://github.com/Shailesh93602/ballast/blob/main/docs/LEDGER.md) — where three of eight findings turned out to be in the checker rather than the system under test — and the KhataGO cases in this post and [the webhook write-up](/blog/khatago-webhook-deduplication-receipt-pipeline) (its repository is currently private)._
+_Each of these is written up with the full diagnosis where it can be read publicly: [EduScale's FINDINGS.md](https://github.com/Shailesh93602/DevScale/blob/main/FINDINGS.md), [BALLAST's ledger](https://github.com/Shailesh93602/ballast/blob/main/docs/LEDGER.md) — where four of nine findings turned out to be in the checker rather than the system under test — and the KhataGO cases in this post and [the webhook write-up](/blog/khatago-webhook-deduplication-receipt-pipeline) (its repository is currently private)._


### PR DESCRIPTION
Upstream shipped L9 tonight — *the mutation harness's negation operator didn't negate* (vacuous `(!a) !== b` mutants deflated the score to a false 87.3%; honest final: **158/165, 95.8%, zero untriaged survivors**, 186→197 tests). This syncs the two numbers the portfolio quotes: the Vitest count in `projects.ts` and the blog's findings sentence (three of eight → four of nine). Local run of `check-project-claims.mjs`: all verifiable claims match. Gate: lint ✓ tsc ✓ tests ✓ format ✓ build ✓