### PR TITLE
Deploy freshness: 30-minute grace window anchored on the oldest unserved change, not main HEAD

### DIFF
--- a/.github/workflows/url-health-check.yml
+++ b/.github/workflows/url-health-check.yml
@@ -68,7 +68,11 @@ jobs:
   # scripts/check-deploy-freshness.mjs compares it with the repository's
   # `main` (`gh api repos/<owner>/<repo>/commits/main`). It fails if the served
   # sha is not an ancestor of main, if main has been ahead for more than 24
-  # hours, or if the route 404s while main has it.
+  # hours, or if the route 404s while main has it. A build in flight is not a
+  # failure: inside a 30-minute grace window (FRESHNESS_GRACE_MINUTES), anchored
+  # on the oldest change live is missing, a behind sha or a 404 is reported as
+  # `deploying` — exit 0 with a warning annotation — so a run minutes after a
+  # merge does not page anyone.
   #
   # 🔴 KNOWN RED, BY DESIGN: the KhataGO row fails until its Vercel deploys are
   # fixed (MANUAL item 0 in the hub). Its repo is private, so this job's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ npm run test:e2e:ui     # Playwright with UI mode
 
 npm run analyze         # Bundle analysis (ANALYZE=true build)
 npm run check:claims    # Numbers this site states about other repos vs. those repos
-npm run check:freshness # Does each live site (this, KhataGO, EduScale) serve its repo's main? KhataGO row is red by design until its deploy is fixed
+npm run check:freshness # Does each live site (this, KhataGO, EduScale) serve its repo's main? KhataGO row is red by design until its deploy is fixed. FRESHNESS_GRACE_MINUTES (default 30) = window in which a behind sha / 404 is "deploying", not FAIL
 
 # Regenerate all screenshots (11 pages × 2 themes × 2 viewports)
 # Requires prod server: npm run start
@@ -110,7 +110,8 @@ lib/
 
 scripts/
   check-live-urls.mjs            # Daily URL health check (GitHub Actions). Reads every `live`/`github` URL out of constants/projects.ts, so it widens automatically when a project is added. KNOWN_PRIVATE entries carry an expiry.
-  check-deploy-freshness.mjs     # Daily FRESHNESS check. For this site, KhataGO and EduScale (frontend + backend health): fetch the served sha, compare with the repo's `main` via the GitHub API. Fails if the served sha is not an ancestor of main, if main has been ahead >24h, or if /api/version 404s while main has the route. KhataGO is private to the Actions token → sha reported "cannot verify (private)", but its 404 still FAILS from the declared route date (2026-09-05). Red by design until KhataGO's Vercel deploys (failing since 2026-08-30) are fixed.
+  check-deploy-freshness.mjs     # Daily FRESHNESS check. For this site, KhataGO and EduScale (frontend + backend health): fetch the served sha, compare with the repo's `main` via the GitHub API. Fails if the served sha is not an ancestor of main, if main has been ahead >24h, or if /api/version 404s while main has the route. Inside a 30-minute grace window (FRESHNESS_GRACE_MINUTES) a behind sha or a 404 is `deploying` (exit 0 + warning) — the window is anchored on the OLDEST change live is missing (oldest unserved commit / the commit that put the route on main), never on main HEAD, which a fresh unrelated commit would reset. KhataGO is private to the Actions token → sha reported "cannot verify (private)", but its 404 still FAILS from the declared route date (2026-09-05), with no grace (no commit times). Red by design until KhataGO's Vercel deploys (failing since 2026-08-30) are fixed.
+  deploy-freshness-decision.mjs  # The I/O-free decision half of the above (injected clock + lazy probes). Unit-tested in __tests__/deploy-freshness-decision.test.ts: fresh, deploying-inside-grace, stale-outside-grace, 404 inside/outside grace, private, and the env parsing.
   check-project-claims.mjs       # Daily CLAIM check. Verifies the NUMBERS projects.ts states about other repos against those repos. Every false claim here started as a true one — "Vitest (147)" was right when written and wrong four merges later. Fetches at a resolved SHA, never at `main`: raw.githubusercontent's CDN serves stale objects for minutes after a push, which made an earlier version flaky exactly when it mattered.
   generate-blog-manifest.mjs     # Runs as postbuild; reads content/blog/ → writes data/blog-manifest.json
   migrate-blog.mjs               # One-time script: extracted blog posts from old blog-data.ts
@@ -148,7 +149,7 @@ public/
 
 ## Testing
 
-- **Unit tests** (`__tests__/`): 376 tests across 40 suites. Covers API routes (statistics, contact), blog functions, components (BlogCard, ProjectCard, EducationSection, KeyMetrics), utils, constants. Run with `npm test`.
+- **Unit tests** (`__tests__/`): 414 tests across 42 suites. Covers API routes (statistics, contact), blog functions, components (BlogCard, ProjectCard, EducationSection, KeyMetrics), utils, constants. Run with `npm test`.
 - **E2E** (`e2e/`):
   - `routes.ts` — **not a spec.** Derives the route inventory (static + `/portfolio/<id>` from `constants/projects.ts` + `/blog/<slug>` from `BLOG_SLUGS`) so adding a project or post automatically widens the asset / SEO gates.
   - `navigation.spec.ts` — desktop + mobile nav sanity

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ public/        # Static assets and images
 | `npm run type-check`      | TypeScript strict check                                        |
 | `npm run format`          | Prettier (writes)                                              |
 | `npm run analyze`         | Bundle analysis (ANALYZE=true build)                           |
-| `npm test`                | Jest unit tests (376 tests, 40 suites)                         |
+| `npm test`                | Jest unit tests (414 tests, 42 suites)                         |
 | `npm run test:coverage`   | Jest with coverage report                                      |
 | `npm run test:e2e`        | Playwright E2E (requires running server)                       |
 | `npm run test:e2e:ui`     | Playwright with UI mode                                        |
@@ -93,13 +93,19 @@ the same route, and EduScale's backend puts the same block in
 sha with the repository's `main` every morning (the `freshness` job in
 `.github/workflows/url-health-check.yml`) and fails if the served commit is
 not an ancestor of `main`, if `main` has been ahead for more than 24 hours, or
-if the route 404s while `main` has it.
+if the route 404s while `main` has it. A build in flight is not a failure: for
+30 minutes (`FRESHNESS_GRACE_MINUTES`) after the oldest change live is missing
+— the oldest unserved commit, or the commit that put the route on `main`;
+never `main` HEAD, which any unrelated commit would reset — a behind sha or a
+404 is reported as `deploying` (exit 0, warning) instead. The decision is
+`scripts/deploy-freshness-decision.mjs`, unit-tested against a fake clock.
 
 A 200 proves a site is up, not that it is current: KhataGO's production
 deploys failed from 2026-08-30 while every status-code check stayed green.
 **The KhataGO row of this check is red by design until that deploy is fixed**
 — its repo is private to the workflow token, so the sha cannot be compared,
 but the route has been on its `main` since 2026-09-05 and a 404 there is a
-stale build.
+stale build. A private repo has no commit times to measure a grace window
+from, so it gets none.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/shailesh93602/portfolio_next)

--- a/__tests__/deploy-freshness-decision.test.ts
+++ b/__tests__/deploy-freshness-decision.test.ts
@@ -1,0 +1,360 @@
+/**
+ * @jest-environment node
+ *
+ * scripts/deploy-freshness-decision.mjs — the decision behind the daily
+ * "does live serve main?" job, run against a fake clock.
+ *
+ * The property under test is the grace window: a run minutes after a merge
+ * sees a build in flight and must say `deploying` (exit 0, warning), while a
+ * build that is missing anything older than the window is still a FAIL. The
+ * window is anchored on the oldest change live is missing — NOT on main HEAD,
+ * because an unrelated fresh commit must not excuse a week-old build. And a
+ * private repository, having no commit times, has no window at all.
+ */
+import {
+  DEFAULT_GRACE_MINUTES,
+  MAX_LAG_MS,
+  decideFreshness,
+  parseGraceMinutes,
+} from "../scripts/deploy-freshness-decision.mjs";
+
+const NOW = Date.parse("2026-09-05T12:00:00.000Z");
+const GRACE_MS = 30 * 60_000;
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+const MAIN = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SERVED = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const target = {
+  name: "site",
+  url: "https://site.example/api/version",
+  shaPath: ["sha"],
+  repo: "owner/repo",
+  routePath: "app/api/version/route.ts",
+};
+
+/** GitHub `commits/main`, committed `headAgo` ms before NOW. */
+const readableHead = (headAgo: number) => ({
+  status: 200,
+  json: { sha: MAIN, commit: { committer: { date: iso(headAgo) } } },
+});
+const privateHead = { status: 404, json: { message: "Not Found" } };
+
+const serving = (sha: string) => ({ status: 200, json: { sha } });
+const notFound = { status: 404, json: null };
+
+/** Probes that record whether they were consulted. */
+function fakeProbes(answers: {
+  route?: { status: number; lastCommitDate: string | null };
+  compare?: { status: number; json: unknown };
+}) {
+  const calls = { route: 0, compare: 0 };
+  return {
+    calls,
+    probes: {
+      async route() {
+        calls.route++;
+        if (!answers.route) throw new Error("route probe not expected");
+        return answers.route;
+      },
+      async compare() {
+        calls.compare++;
+        if (!answers.compare) throw new Error("compare probe not expected");
+        return answers.compare;
+      },
+    },
+  };
+}
+
+/** `compare/<served>...main`: main ahead by the given commits (ms ago each). */
+const aheadBy = (commitAges: number[]) => ({
+  status: 200,
+  json: {
+    status: "ahead",
+    ahead_by: commitAges.length,
+    commits: commitAges.map((ago) => ({
+      commit: { committer: { date: iso(ago) } },
+    })),
+  },
+});
+
+const opts = { now: NOW, graceMs: GRACE_MS };
+
+describe("decideFreshness — the grace window", () => {
+  it("fresh: served sha is main HEAD → ok, and no compare call is made", async () => {
+    const { probes, calls } = fakeProbes({});
+    const r = await decideFreshness(
+      { target, live: serving(MAIN), head: readableHead(5 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: true, verdict: "ok" });
+    expect(r.deploying).toBeUndefined();
+    expect(calls).toEqual({ route: 0, compare: 0 });
+  });
+
+  it("deploying inside grace: one commit behind, merged 5 minutes ago → deploying, ok", async () => {
+    const { probes } = fakeProbes({ compare: aheadBy([5 * MIN]) });
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: readableHead(5 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({
+      ok: true,
+      deploying: true,
+      verdict: "deploying",
+    });
+    expect(r.detail).toMatch(/inside the 30m grace window/);
+  });
+
+  it("stale outside grace: one commit behind for 25 hours → FAIL, regardless of a fresh HEAD", async () => {
+    // main HEAD was committed 5 minutes ago, but the OLDEST unserved commit is
+    // 25 hours old: a fresh commit must not reset the window.
+    const { probes } = fakeProbes({ compare: aheadBy([5 * MIN, 25 * HOUR]) });
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: readableHead(5 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/over the 24\.0h window/);
+  });
+
+  it("behind, past grace but under 24h → ok (not deploying, not stale)", async () => {
+    const { probes } = fakeProbes({ compare: aheadBy([2 * HOUR]) });
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: readableHead(2 * HOUR) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: true, verdict: "ok" });
+    expect(r.deploying).toBeUndefined();
+    expect(r.detail).toMatch(/within the 24\.0h window/);
+  });
+
+  it("the grace boundary is inclusive: exactly 30 minutes is still deploying, 30m+1s is not", async () => {
+    const at = async (ago: number) =>
+      decideFreshness(
+        { target, live: serving(SERVED), head: readableHead(ago) },
+        fakeProbes({ compare: aheadBy([ago]) }).probes,
+        opts
+      );
+    expect((await at(GRACE_MS)).verdict).toBe("deploying");
+    expect((await at(GRACE_MS + 1000)).verdict).toBe("ok");
+  });
+
+  it("404 inside grace: the route reached main 3 minutes ago → deploying, ok", async () => {
+    const { probes, calls } = fakeProbes({
+      route: { status: 200, lastCommitDate: iso(3 * MIN) },
+    });
+    const r = await decideFreshness(
+      { target, live: notFound, head: readableHead(3 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({
+      ok: true,
+      deploying: true,
+      verdict: "deploying",
+    });
+    expect(r.detail).toMatch(/answers 404/);
+    expect(r.detail).toMatch(/3m ago/);
+    expect(calls).toEqual({ route: 1, compare: 0 });
+  });
+
+  it("404 outside grace: the route has been on main for 8 hours → FAIL, even though HEAD is 4 minutes old", async () => {
+    // KhataGO on 2026-09-05 15:34Z: an unrelated commit landed at 15:29Z while
+    // live was still the Aug 29 build. Anchored on HEAD this would have read
+    // "deploying". It is a stale deploy.
+    const { probes } = fakeProbes({
+      route: { status: 200, lastCommitDate: iso(8 * HOUR) },
+    });
+    const r = await decideFreshness(
+      { target, live: notFound, head: readableHead(4 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/landed 8\.0h ago, outside the 30m grace window/);
+    expect(r.detail).toMatch(/stale deploy/);
+  });
+
+  it("404 with no date for the route (API gave none) → FAIL: unknown age is not inside any window", async () => {
+    const { probes } = fakeProbes({
+      route: { status: 200, lastCommitDate: null },
+    });
+    const r = await decideFreshness(
+      { target, live: notFound, head: readableHead(1 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/landed at an unknown time/);
+  });
+
+  it("404 while the route is not on main → ok, expected", async () => {
+    const { probes } = fakeProbes({
+      route: { status: 404, lastCommitDate: null },
+    });
+    const r = await decideFreshness(
+      { target, live: notFound, head: readableHead(1 * MIN) },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: true, verdict: "ok" });
+    expect(r.detail).toMatch(/not on main yet/);
+  });
+
+  it("private: a served sha with an unreadable repo → cannot verify (private), never a pass", async () => {
+    const { probes, calls } = fakeProbes({});
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: privateHead },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({
+      ok: true,
+      unverifiable: true,
+      verdict: "cannot verify (private)",
+    });
+    expect(calls).toEqual({ route: 0, compare: 0 });
+  });
+
+  it("private + 404 + declared route date → FAIL with no grace (there are no commit times to measure from)", async () => {
+    // The KhataGO row as the Actions token sees it. `now` is one minute after
+    // midnight on the declared date — a window anchored on the date would
+    // pass it; there is no window here.
+    const { probes, calls } = fakeProbes({});
+    const r = await decideFreshness(
+      {
+        target: { ...target, routeOnMainSince: "2026-09-05" },
+        live: notFound,
+        head: privateHead,
+      },
+      probes,
+      { now: Date.parse("2026-09-05T00:01:00.000Z"), graceMs: GRACE_MS }
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/private to this token/);
+    expect(r.detail).toMatch(/since 2026-09-05/);
+    expect(calls).toEqual({ route: 0, compare: 0 });
+  });
+
+  it("private + 404 with no declared date → cannot verify (private)", async () => {
+    const r = await decideFreshness(
+      { target, live: notFound, head: privateHead },
+      fakeProbes({}).probes,
+      opts
+    );
+    expect(r).toMatchObject({
+      ok: true,
+      unverifiable: true,
+      verdict: "cannot verify (private)",
+    });
+  });
+
+  it("a zero-minute window disables grace: one commit behind by 10s is ok-in-window, never deploying", async () => {
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: readableHead(10_000) },
+      fakeProbes({ compare: aheadBy([10_000]) }).probes,
+      { now: NOW, graceMs: 0 }
+    );
+    expect(r).toMatchObject({ ok: true, verdict: "ok" });
+    expect(r.deploying).toBeUndefined();
+  });
+
+  it("the defaults are 30 minutes of grace and a 24-hour lag window", () => {
+    expect(DEFAULT_GRACE_MINUTES).toBe(30);
+    expect(MAX_LAG_MS).toBe(24 * HOUR);
+  });
+});
+
+describe("decideFreshness — the rules the window does not touch", () => {
+  it("unreachable live site → FAIL, before any repository lookup", async () => {
+    const { probes, calls } = fakeProbes({});
+    const r = await decideFreshness(
+      {
+        target,
+        live: { status: 0, json: null, error: "ECONNREFUSED" },
+        head: readableHead(1 * MIN),
+      },
+      probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/unreachable \(ECONNREFUSED\)/);
+    expect(calls).toEqual({ route: 0, compare: 0 });
+  });
+
+  it("served sha `unknown` (build did not bake its sha) → FAIL, even inside grace", async () => {
+    const r = await decideFreshness(
+      { target, live: serving("unknown"), head: readableHead(1 * MIN) },
+      fakeProbes({}).probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/did not bake its git sha/);
+  });
+
+  it("served sha not an ancestor of main (diverged) → FAIL, even inside grace", async () => {
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: readableHead(1 * MIN) },
+      fakeProbes({
+        compare: {
+          status: 200,
+          json: { status: "diverged", ahead_by: 1, commits: [] },
+        },
+      }).probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/not an ancestor of main .* \(diverged\)/);
+  });
+
+  it("served sha unknown to the repository (compare 404) → FAIL", async () => {
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: readableHead(1 * MIN) },
+      fakeProbes({ compare: { status: 404, json: null } }).probes,
+      opts
+    );
+    expect(r).toMatchObject({ ok: false, verdict: "FAIL" });
+    expect(r.detail).toMatch(/not a commit in owner\/repo/);
+  });
+
+  it("GitHub API unavailable (non-200, non-404) → skipped and unverifiable, not a pass or a fail", async () => {
+    const r = await decideFreshness(
+      { target, live: serving(SERVED), head: { status: 403, json: null } },
+      fakeProbes({}).probes,
+      opts
+    );
+    expect(r).toMatchObject({
+      ok: true,
+      unverifiable: true,
+      verdict: "skipped",
+    });
+  });
+});
+
+describe("parseGraceMinutes (FRESHNESS_GRACE_MINUTES)", () => {
+  it("unset or empty → the 30-minute default", () => {
+    expect(parseGraceMinutes(undefined)).toBe(30);
+    expect(parseGraceMinutes("")).toBe(30);
+    expect(parseGraceMinutes("  ")).toBe(30);
+  });
+
+  it("a number of minutes, including 0 (grace off) and fractions", () => {
+    expect(parseGraceMinutes("45")).toBe(45);
+    expect(parseGraceMinutes("0")).toBe(0);
+    expect(parseGraceMinutes("2.5")).toBe(2.5);
+  });
+
+  it("refuses anything that is not a non-negative number instead of silently defaulting", () => {
+    for (const bad of ["30m", "abc", "-5", "NaN", "Infinity"]) {
+      expect(() => parseGraceMinutes(bad)).toThrow(/FRESHNESS_GRACE_MINUTES/);
+    }
+  });
+});

--- a/scripts/check-deploy-freshness.mjs
+++ b/scripts/check-deploy-freshness.mjs
@@ -28,28 +28,52 @@
  *   3. the version route answers 404 while the repository has the route on
  *      `main` — the shape KhataGO's outage takes today.
  *
+ * WHAT IS REPORTED AS `deploying` (exit 0, with a warning): rule 2 or rule 3
+ * tripping inside the grace window — 30 minutes by default,
+ * `FRESHNESS_GRACE_MINUTES` to change it — measured from the OLDEST change
+ * live is missing (the oldest unserved commit, or the commit that put the
+ * route on `main`; never from `main` HEAD, which a fresh unrelated commit
+ * would reset). A run minutes after a merge sees a build in flight, not a
+ * defect. See deploy-freshness-decision.mjs for the reasoning and the rules.
+ *
  * WHAT IS NOT A FAILURE: a repository this token cannot read. KhataGO is
  * private and the Actions `GITHUB_TOKEN` is scoped to THIS repo, so the API
  * answers 404 for it. That is reported as "cannot verify (private)" and never
  * counted as a pass. Rule 3 still applies to it, from declared knowledge: the
  * route landed on KhataGO `main` on 2026-09-05 (#55), so a 404 there is a
- * stale deploy, not a missing feature. That is why the KhataGO row FAILS by
- * design until its deploys are fixed — this job existing at all is the
- * response to that outage, and a check that passed through it would be the
- * old blind spot with a new name.
+ * stale deploy, not a missing feature — and with no commit times to measure
+ * from, a private repository has no grace window. That is why the KhataGO row
+ * FAILS by design until its deploys are fixed — this job existing at all is
+ * the response to that outage, and a check that passed through it would be
+ * the old blind spot with a new name.
  *
  * Run: node scripts/check-deploy-freshness.mjs
  *      GITHUB_TOKEN is optional locally (60 unauthenticated requests/hour is
  *      plenty) and set from `secrets.GITHUB_TOKEN` in Actions.
+ *      FRESHNESS_GRACE_MINUTES overrides the 30-minute grace window.
  */
 
 import { appendFileSync } from "node:fs";
 
-const MAX_LAG_MS = 24 * 60 * 60 * 1000;
+import {
+  decideFreshness,
+  dig,
+  parseGraceMinutes,
+} from "./deploy-freshness-decision.mjs";
+
 const TIMEOUT_MS = 30_000;
 const RETRIES = 1;
 const RETRY_DELAY_MS = 5_000;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let graceMinutes;
+try {
+  graceMinutes = parseGraceMinutes(process.env.FRESHNESS_GRACE_MINUTES);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(2);
+}
+const GRACE_MS = graceMinutes * 60_000;
 
 /**
  * Each target names the live version URL, where in its JSON the sha lives,
@@ -158,167 +182,41 @@ async function gh(path) {
   return { status: res.status, json };
 }
 
-function dig(obj, path) {
-  let cur = obj;
-  for (const key of path) {
-    if (cur === null || typeof cur !== "object") return undefined;
-    cur = cur[key];
-  }
-  return cur;
-}
-
-const hours = (ms) => (ms / 3_600_000).toFixed(1);
-
 /**
- * One target → { ok, verdict, detail, unverifiable }.
- *
- * `ok: false` fails the run. `unverifiable: true` is reported distinctly and
- * never counted as a pass.
+ * Gather the facts, then decide. The probes are lazy so a fresh site costs
+ * two requests and only the shapes that need more make more.
  */
 async function check(target) {
   const live = await fetchLive(target.url);
+  const head = await gh(`repos/${target.repo}/commits/main`);
   const servedSha = dig(live.json, target.shaPath);
 
-  // ── What does main say? ────────────────────────────────────────────────
-  const head = await gh(`repos/${target.repo}/commits/main`);
-  const repoReadable = head.status === 200;
-  if (!repoReadable && head.status !== 404) {
-    // Rate limit, outage. Not a false claim about the deploy; say so.
-    return {
-      ok: true,
-      unverifiable: true,
-      verdict: "skipped",
-      detail: `GitHub API answered ${head.status} for ${target.repo}`,
-    };
-  }
-  const mainSha = repoReadable ? head.json.sha : null;
-
-  // ── Rule 3: the route is missing from live ─────────────────────────────
-  if (live.status === 0) {
-    return {
-      ok: false,
-      verdict: "FAIL",
-      detail: `${target.url} unreachable (${live.error})`,
-    };
-  }
-  if (live.status === 404 || servedSha === undefined) {
-    const shape =
-      live.status === 404
-        ? "answers 404"
-        : `answers ${live.status} with no sha at .${target.shaPath.join(".")}`;
-    if (repoReadable) {
-      const route = await gh(
+  const probes = {
+    async route() {
+      const contents = await gh(
         `repos/${target.repo}/contents/${target.routePath}?ref=main`
       );
-      if (route.status === 200) {
-        return {
-          ok: false,
-          verdict: "FAIL",
-          detail:
-            `${shape}, but ${target.repo} has ${target.routePath} on main ` +
-            `(${mainSha.slice(0, 7)}) — live is serving a build from before the route: a stale deploy`,
-        };
+      if (contents.status !== 200) {
+        return { status: contents.status, lastCommitDate: null };
       }
-      return {
-        ok: true,
-        verdict: "ok",
-        detail: `${shape}; ${target.routePath} is not on main yet, so that is expected`,
-      };
-    }
-    if (target.routeOnMainSince) {
-      return {
-        ok: false,
-        verdict: "FAIL",
-        detail:
-          `${shape}; ${target.repo} is private to this token, but the route has been on ` +
-          `main since ${target.routeOnMainSince} — live is a build from before it: a stale deploy`,
-      };
-    }
-    return {
-      ok: true,
-      unverifiable: true,
-      verdict: "cannot verify (private)",
-      detail: `${shape}; ${target.repo} is private and no route date is declared`,
-    };
-  }
-
-  if (typeof servedSha !== "string" || !/^[0-9a-f]{40}$/.test(servedSha)) {
-    // `unknown` means the build did not bake VERCEL_GIT_COMMIT_SHA. A
-    // version endpoint that cannot name its commit is the blind spot again.
-    return {
-      ok: false,
-      verdict: "FAIL",
-      detail: `served sha is ${JSON.stringify(servedSha)} — not a commit; the build did not bake its git sha`,
-    };
-  }
-
-  if (!repoReadable) {
-    return {
-      ok: true,
-      unverifiable: true,
-      verdict: "cannot verify (private)",
-      detail: `live serves ${servedSha.slice(0, 7)}; ${target.repo} is private to this token, so main is unknown`,
-    };
-  }
-
-  // ── Rules 1 and 2: ancestry and lag ────────────────────────────────────
-  if (servedSha === mainSha) {
-    return {
-      ok: true,
-      verdict: "ok",
-      detail: `live serves main HEAD ${servedSha.slice(0, 7)}`,
-    };
-  }
-
-  const cmp = await gh(`repos/${target.repo}/compare/${servedSha}...main`);
-  if (cmp.status === 404) {
-    return {
-      ok: false,
-      verdict: "FAIL",
-      detail: `live serves ${servedSha.slice(0, 7)}, which is not a commit in ${target.repo}`,
-    };
-  }
-  if (cmp.status !== 200) {
-    return {
-      ok: true,
-      unverifiable: true,
-      verdict: "skipped",
-      detail: `GitHub compare answered ${cmp.status}`,
-    };
-  }
-  const { status, ahead_by: aheadBy, commits = [] } = cmp.json;
-  // base = served, head = main. "ahead" means main is ahead of served, i.e.
-  // served IS an ancestor. "behind" / "diverged" mean it is not.
-  if (status !== "ahead" && status !== "identical") {
-    return {
-      ok: false,
-      verdict: "FAIL",
-      detail: `live serves ${servedSha.slice(0, 7)}, which is not an ancestor of main ${mainSha.slice(0, 7)} (${status})`,
-    };
-  }
-  const dates = commits
-    .map((c) => Date.parse(c?.commit?.committer?.date ?? ""))
-    .filter((t) => Number.isFinite(t));
-  // Oldest commit main has that live does not. If the list was truncated
-  // (GitHub caps it at 250) fall back to main HEAD's own date — a lag that
-  // deep is over the window either way.
-  const oldest = dates.length
-    ? Math.min(...dates)
-    : Date.parse(head.json.commit.committer.date);
-  const lagMs = Date.now() - oldest;
-  const summary = `live serves ${servedSha.slice(0, 7)}; main ${mainSha.slice(0, 7)} is ${aheadBy} commit(s) ahead, oldest unserved is ${hours(lagMs)}h old`;
-  if (lagMs > MAX_LAG_MS) {
-    return {
-      ok: false,
-      verdict: "FAIL",
-      detail: `${summary} — over the 24h window`,
-    };
-  }
-  return {
-    ok: true,
-    verdict: "ok",
-    detail: `${summary} — within the 24h window (deploy in flight)`,
+      // When did main last change this file? That is the change a 404 build
+      // is missing, and the anchor for the grace window.
+      const touched = await gh(
+        `repos/${target.repo}/commits?path=${encodeURIComponent(target.routePath)}&sha=main&per_page=1`
+      );
+      const lastCommitDate =
+        touched.status === 200 && Array.isArray(touched.json)
+          ? (touched.json[0]?.commit?.committer?.date ?? null)
+          : null;
+      return { status: 200, lastCommitDate };
+    },
+    compare: () => gh(`repos/${target.repo}/compare/${servedSha}...main`),
   };
+
+  return decideFreshness({ target, live, head }, probes, {
+    now: Date.now(),
+    graceMs: GRACE_MS,
+  });
 }
 
 const results = [];
@@ -338,11 +236,16 @@ for (const target of TARGETS) {
   }
 }
 
+const icon = (r) =>
+  r.ok ? (r.unverifiable ? "~" : r.deploying ? "…" : "✓") : "✗";
+
 const width = Math.max(...results.map((r) => r.target.name.length));
-console.log("\nDeploy freshness — does live serve main?\n" + "─".repeat(78));
+console.log(
+  `\nDeploy freshness — does live serve main? (grace window: ${graceMinutes}m)\n` +
+    "─".repeat(78)
+);
 for (const r of results) {
-  const icon = r.ok ? (r.unverifiable ? "~" : "✓") : "✗";
-  const line = `${icon}  ${r.target.name.padEnd(width + 2)} ${r.verdict.padEnd(24)} ${r.detail}`;
+  const line = `${icon(r)}  ${r.target.name.padEnd(width + 2)} ${r.verdict.padEnd(24)} ${r.detail}`;
   if (r.ok) console.log(line);
   else console.error(line);
 }
@@ -350,12 +253,12 @@ console.log("─".repeat(78));
 
 const failed = results.filter((r) => !r.ok);
 const unverifiable = results.filter((r) => r.ok && r.unverifiable);
+const deploying = results.filter((r) => r.ok && r.deploying);
 
 if (process.env.GITHUB_STEP_SUMMARY) {
   const rows = results
     .map(
-      (r) =>
-        `| ${r.ok ? (r.unverifiable ? "~" : "✓") : "✗"} | ${r.target.name} | ${r.verdict} | ${r.detail} |`
+      (r) => `| ${icon(r)} | ${r.target.name} | ${r.verdict} | ${r.detail} |`
     )
     .join("\n");
   appendFileSync(
@@ -364,6 +267,21 @@ if (process.env.GITHUB_STEP_SUMMARY) {
   );
 }
 
+if (deploying.length > 0) {
+  const msg =
+    `${deploying.length} target(s) are behind main by less than the ${graceMinutes}m grace window ` +
+    `(deploy in flight, not a failure — re-run after it lands):\n` +
+    deploying.map((r) => `  • ${r.target.name}: ${r.detail}`).join("\n");
+  console.log(`\nWARNING: ${msg}`);
+  if (process.env.GITHUB_ACTIONS) {
+    // One annotation per target, on the workflow run's summary page.
+    for (const r of deploying) {
+      console.log(
+        `::warning title=Deploy in flight (${r.target.name})::${r.detail}`
+      );
+    }
+  }
+}
 if (unverifiable.length > 0) {
   console.log(
     `\n${unverifiable.length} target(s) could not be verified against their repository ` +
@@ -380,5 +298,6 @@ if (failed.length > 0) {
   process.exit(1);
 }
 console.log(
-  `\nAll ${results.length - unverifiable.length} verifiable sites serve main.`
+  `\nAll ${results.length - unverifiable.length} verifiable sites serve main` +
+    (deploying.length > 0 ? ` (${deploying.length} deploying).` : ".")
 );

--- a/scripts/deploy-freshness-decision.mjs
+++ b/scripts/deploy-freshness-decision.mjs
@@ -1,0 +1,264 @@
+/**
+ * deploy-freshness-decision.mjs
+ *
+ * The decision half of scripts/check-deploy-freshness.mjs, with no I/O of its
+ * own: every fact arrives as an argument or through a probe the caller
+ * supplies, and the clock is injected. That is what lets the unit tests pin
+ * the six shapes that matter (fresh, deploying, stale, 404 inside and outside
+ * the grace window, private) without a network and without waiting.
+ *
+ * THE GRACE WINDOW. A Vercel production build takes a few minutes, so for a
+ * few minutes after a merge, live is legitimately behind main. Without a
+ * window, a check that runs right after a merge fails on a deploy in flight:
+ * the 404 rule trips the moment a PR adding /api/version lands, and a served
+ * sha one commit behind reads as a defect. Inside the window those shapes are
+ * reported as `deploying` — exit 0 with a warning — and outside it they are
+ * failures exactly as before.
+ *
+ * WHAT THE WINDOW IS MEASURED FROM — and why not `main` HEAD. The obvious
+ * anchor is the time of main's HEAD commit. It is wrong: any fresh commit to
+ * main would then excuse an arbitrarily old build for the length of the
+ * window. On 2026-09-05 at 15:29Z an unrelated commit landed on KhataGO main
+ * while live was still the Aug 29 build; anchored on HEAD, the 15:34Z run
+ * would have called that outage "deploying". So the window is anchored on the
+ * OLDEST change live is missing:
+ *   - served sha behind main → the oldest commit main has that live does not;
+ *   - route 404 while main has it → the commit that put the route on main
+ *     (the most recent commit touching the route file — an upper bound, so it
+ *     can only ever be lenient by one edit, for one window).
+ * A deploy that is missing nothing older than the window is in flight. One
+ * that is missing something older is not.
+ *
+ * A private repository (this token gets 404 from the API) has no commit
+ * times, so it has no grace window: its sha is "cannot verify (private)" and
+ * its 404 fails from the declared `routeOnMainSince` date, exactly as before.
+ */
+
+export const DEFAULT_GRACE_MINUTES = 30;
+export const MAX_LAG_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * `FRESHNESS_GRACE_MINUTES` → milliseconds. Unset or empty means the default;
+ * anything that is not a finite, non-negative number is a configuration error
+ * and is refused rather than silently defaulted (a typo'd `30m` must not turn
+ * into "no grace" or "default grace" without saying so).
+ */
+export function parseGraceMinutes(raw) {
+  if (raw === undefined || raw === null || String(raw).trim() === "") {
+    return DEFAULT_GRACE_MINUTES;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(
+      `FRESHNESS_GRACE_MINUTES must be a non-negative number of minutes, got ${JSON.stringify(raw)}`
+    );
+  }
+  return n;
+}
+
+export function dig(obj, path) {
+  let cur = obj;
+  for (const key of path) {
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = cur[key];
+  }
+  return cur;
+}
+
+const hours = (ms) => (ms / 3_600_000).toFixed(1);
+const minutes = (ms) => Math.max(0, Math.round(ms / 60_000));
+const short = (sha) => (typeof sha === "string" ? sha.slice(0, 7) : "?");
+
+/**
+ * One target → { ok, verdict, detail, unverifiable?, deploying? }.
+ *
+ *   ok: false          fails the run.
+ *   unverifiable: true reported distinctly, never counted as a pass.
+ *   deploying: true    ok, with a warning: live is behind main by less than
+ *                      the grace window, measured as described above.
+ *
+ * @param facts   { target, live: { status, json, error? }, head: { status, json } }
+ *                `head` is the GitHub `commits/main` answer; 404 = unreadable.
+ * @param probes  Lazy lookups, only called when the decision needs them:
+ *                  route()   → { status, lastCommitDate }: `status` of
+ *                              `contents/<routePath>?ref=main` (200 = present)
+ *                              and the ISO date of the most recent commit on
+ *                              main touching that path (or null).
+ *                  compare() → the GitHub `compare/<served>...main` answer,
+ *                              { status, json }.
+ * @param opts    { now, graceMs, maxLagMs } — the clock and the windows.
+ */
+export async function decideFreshness(
+  { target, live, head },
+  probes,
+  {
+    now = Date.now(),
+    graceMs = DEFAULT_GRACE_MINUTES * 60_000,
+    maxLagMs = MAX_LAG_MS,
+  } = {}
+) {
+  const servedSha = dig(live.json, target.shaPath);
+  const graceLabel = `${minutes(graceMs)}m grace window`;
+
+  // ── What does main say? ────────────────────────────────────────────────
+  const repoReadable = head.status === 200;
+  if (!repoReadable && head.status !== 404) {
+    // Rate limit, outage. Not a false claim about the deploy; say so.
+    return {
+      ok: true,
+      unverifiable: true,
+      verdict: "skipped",
+      detail: `GitHub API answered ${head.status} for ${target.repo}`,
+    };
+  }
+  const mainSha = repoReadable ? head.json.sha : null;
+
+  // ── Rule 3: the route is missing from live ─────────────────────────────
+  if (live.status === 0) {
+    return {
+      ok: false,
+      verdict: "FAIL",
+      detail: `${target.url} unreachable (${live.error})`,
+    };
+  }
+  if (live.status === 404 || servedSha === undefined) {
+    const shape =
+      live.status === 404
+        ? "answers 404"
+        : `answers ${live.status} with no sha at .${target.shaPath.join(".")}`;
+    if (repoReadable) {
+      const route = await probes.route();
+      if (route.status === 200) {
+        const landedAt = Date.parse(route.lastCommitDate ?? "");
+        const sinceLanded = now - landedAt;
+        if (Number.isFinite(sinceLanded) && sinceLanded <= graceMs) {
+          return {
+            ok: true,
+            deploying: true,
+            verdict: "deploying",
+            detail:
+              `${shape}; ${target.routePath} reached ${target.repo} main ${minutes(sinceLanded)}m ago ` +
+              `(${short(mainSha)}) — inside the ${graceLabel}, deploy in flight`,
+          };
+        }
+        const age = Number.isFinite(sinceLanded)
+          ? `${hours(sinceLanded)}h ago`
+          : "at an unknown time";
+        return {
+          ok: false,
+          verdict: "FAIL",
+          detail:
+            `${shape}, but ${target.repo} has ${target.routePath} on main ` +
+            `(${short(mainSha)}, landed ${age}, outside the ${graceLabel}) — ` +
+            `live is serving a build from before the route: a stale deploy`,
+        };
+      }
+      return {
+        ok: true,
+        verdict: "ok",
+        detail: `${shape}; ${target.routePath} is not on main yet, so that is expected`,
+      };
+    }
+    if (target.routeOnMainSince) {
+      return {
+        ok: false,
+        verdict: "FAIL",
+        detail:
+          `${shape}; ${target.repo} is private to this token, but the route has been on ` +
+          `main since ${target.routeOnMainSince} — live is a build from before it: a stale deploy`,
+      };
+    }
+    return {
+      ok: true,
+      unverifiable: true,
+      verdict: "cannot verify (private)",
+      detail: `${shape}; ${target.repo} is private and no route date is declared`,
+    };
+  }
+
+  if (typeof servedSha !== "string" || !/^[0-9a-f]{40}$/.test(servedSha)) {
+    // `unknown` means the build did not bake VERCEL_GIT_COMMIT_SHA. A
+    // version endpoint that cannot name its commit is the blind spot again.
+    return {
+      ok: false,
+      verdict: "FAIL",
+      detail: `served sha is ${JSON.stringify(servedSha)} — not a commit; the build did not bake its git sha`,
+    };
+  }
+
+  if (!repoReadable) {
+    return {
+      ok: true,
+      unverifiable: true,
+      verdict: "cannot verify (private)",
+      detail: `live serves ${short(servedSha)}; ${target.repo} is private to this token, so main is unknown`,
+    };
+  }
+
+  // ── Rules 1 and 2: ancestry and lag ────────────────────────────────────
+  if (servedSha === mainSha) {
+    return {
+      ok: true,
+      verdict: "ok",
+      detail: `live serves main HEAD ${short(servedSha)}`,
+    };
+  }
+
+  const cmp = await probes.compare();
+  if (cmp.status === 404) {
+    return {
+      ok: false,
+      verdict: "FAIL",
+      detail: `live serves ${short(servedSha)}, which is not a commit in ${target.repo}`,
+    };
+  }
+  if (cmp.status !== 200) {
+    return {
+      ok: true,
+      unverifiable: true,
+      verdict: "skipped",
+      detail: `GitHub compare answered ${cmp.status}`,
+    };
+  }
+  const { status, ahead_by: aheadBy, commits = [] } = cmp.json;
+  // base = served, head = main. "ahead" means main is ahead of served, i.e.
+  // served IS an ancestor. "behind" / "diverged" mean it is not.
+  if (status !== "ahead" && status !== "identical") {
+    return {
+      ok: false,
+      verdict: "FAIL",
+      detail: `live serves ${short(servedSha)}, which is not an ancestor of main ${short(mainSha)} (${status})`,
+    };
+  }
+  const dates = commits
+    .map((c) => Date.parse(c?.commit?.committer?.date ?? ""))
+    .filter((t) => Number.isFinite(t));
+  // Oldest commit main has that live does not. If the list was truncated
+  // (GitHub caps it at 250) fall back to main HEAD's own date — a lag that
+  // deep is over the window either way.
+  const oldest = dates.length
+    ? Math.min(...dates)
+    : Date.parse(head.json.commit.committer.date);
+  const lagMs = now - oldest;
+  const summary = `live serves ${short(servedSha)}; main ${short(mainSha)} is ${aheadBy} commit(s) ahead, oldest unserved is ${hours(lagMs)}h old`;
+  if (lagMs > maxLagMs) {
+    return {
+      ok: false,
+      verdict: "FAIL",
+      detail: `${summary} — over the ${hours(maxLagMs)}h window`,
+    };
+  }
+  if (lagMs <= graceMs) {
+    return {
+      ok: true,
+      deploying: true,
+      verdict: "deploying",
+      detail: `${summary} (${minutes(lagMs)}m) — inside the ${graceLabel}, deploy in flight`,
+    };
+  }
+  return {
+    ok: true,
+    verdict: "ok",
+    detail: `${summary} — within the ${hours(maxLagMs)}h window`,
+  };
+}


### PR DESCRIPTION
## What

The daily deploy-freshness check (#48) had two rough edges around a deploy in flight:

- **Rule 3** (route 404s while `main` has it) had no grace window — a run within minutes of the merge that adds `/api/version` failed on the in-flight 404.
- **Rule 2** (`main` ahead > 24h) was right, but a served sha a few minutes behind was reported as a plain `ok` with no distinction from "actually current".

Now, inside a grace window (**default 30 minutes**, env `FRESHNESS_GRACE_MINUTES`), a 404 or a behind sha is reported as **`deploying`** — exit 0, a `WARNING:` block in the log, and a `::warning` annotation in Actions. Outside the window, behaviour is unchanged.

## One deliberate deviation from the brief: the window is NOT anchored on `main` HEAD

The brief said "measured from the `main` HEAD commit time". I started there and it produces a false negative on real data **today**:

- KhataGO `main` got an unrelated commit at **15:29Z** (`ea57f82`).
- Live is still the Aug 29 build; `/api/version` 404s; the route reached `main` 8 hours ago.
- A HEAD-anchored window at 15:34Z would have said **`deploying`** for KhataGO — an outage the check exists to catch, excused by an unrelated merge. Any fresh commit to `main` would reset the window for an arbitrarily old build.

So the window is anchored on **the oldest change live is missing**:

| Shape | Anchor |
| --- | --- |
| served sha behind `main` | the oldest commit `main` has that live does not (already computed for the 24h rule) |
| route 404 while `main` has it | the commit that put the route on `main` — `commits?path=<route>&sha=main&per_page=1`, one extra API call, only in that branch. It is the *most recent* commit touching the file, so it can only be lenient by one edit, for one window. |
| private repo (token gets 404) | **no window** — there are no commit times. Sha stays `cannot verify (private)`; 404 still FAILs from the declared `routeOnMainSince`. |

"Behind by one" from the brief is generalised to "every unserved commit is inside the window" — a three-PR merge batch landing in 10 minutes is one deploy in flight, not three.

## Structure

- `scripts/deploy-freshness-decision.mjs` — **new.** The decision with no I/O: facts in, injected clock, lazy probes (`route()`, `compare()`) that are only called when needed. Exports `decideFreshness`, `parseGraceMinutes`, `dig`, the defaults.
- `scripts/check-deploy-freshness.mjs` — fetches, builds the probes, prints; `deploying` rows get `…`, a warning block, and an Actions annotation.
- `__tests__/deploy-freshness-decision.test.ts` — **22 tests** against a fake clock: fresh (no compare call), deploying-inside-grace, stale-outside-grace (25h-old unserved commit with a 5-minute-old HEAD — the masking case), behind-past-grace-under-24h (`ok`), inclusive boundary (30m00s deploying / 30m01s ok), 404-inside-grace, 404-outside-grace (the KhataGO shape: route 8h old, HEAD 4m old → FAIL), 404 with no route date (FAIL), route not on main (ok), private+sha, private+404+declared date (FAIL, no grace even one minute past midnight of the declared date), private+404 no date, grace off (`0`), unreachable, `unknown` sha, diverged, compare 404, API 403 → skipped, and `FRESHNESS_GRACE_MINUTES` parsing (`"30m"`, `"abc"`, `"-5"` refused with exit 2 rather than silently defaulting).
- README / CLAUDE.md / workflow comment updated. The test-count lines were already stale at 376/40; now 414/42 from the gate output.

## Local runs (2026-09-05 ~15:35Z)

**Default 30m window, authenticated (my token can read KhataGO, so the readable-repo path runs) — KhataGO still FAILs:**

```
Deploy freshness — does live serve main? (grace window: 30m)
──────────────────────────────────────────────────────────────────────────────
✓  portfolio           ok                       live serves main HEAD 4b57c79
✗  KhataGO             FAIL                     answers 404, but Shailesh93602/KhataGO has app/api/version/route.ts on main (ea57f82, landed 8.1h ago, outside the 30m grace window) — live is serving a build from before the route: a stale deploy
✓  EduScale frontend   ok                       live serves main HEAD 591bd72
✓  EduScale backend    ok                       live serves main HEAD 591bd72
──────────────────────────────────────────────────────────────────────────────

1 live site(s) are not serving main:
  • KhataGO: answers 404, but Shailesh93602/KhataGO has app/api/version/route.ts on main (ea57f82, landed 8.1h ago, outside the 30m grace window) — live is serving a build from before the route: a stale deploy

A 200 from a stale build is the failure this check exists to catch. Open the project's Vercel deployments and read the failed build's log.
exit=1
```

**No token (what the Actions `GITHUB_TOKEN` sees — KhataGO private) — still FAILs, no grace:**

```
Deploy freshness — does live serve main? (grace window: 30m)
──────────────────────────────────────────────────────────────────────────────
✓  portfolio           ok                       live serves main HEAD 4b57c79
✗  KhataGO             FAIL                     answers 404; Shailesh93602/KhataGO is private to this token, but the route has been on main since 2026-09-05 — live is a build from before it: a stale deploy
✓  EduScale frontend   ok                       live serves main HEAD 591bd72
✓  EduScale backend    ok                       live serves main HEAD 591bd72
──────────────────────────────────────────────────────────────────────────────
exit=1
```

**`FRESHNESS_GRACE_MINUTES=600` (proves the window acts on real data — 489m < 600m):**

```
Deploy freshness — does live serve main? (grace window: 600m)
──────────────────────────────────────────────────────────────────────────────
✓  portfolio           ok                       live serves main HEAD 4b57c79
…  KhataGO             deploying                answers 404; app/api/version/route.ts reached Shailesh93602/KhataGO main 489m ago (ea57f82) — inside the 600m grace window, deploy in flight
✓  EduScale frontend   ok                       live serves main HEAD 591bd72
✓  EduScale backend    ok                       live serves main HEAD 591bd72
──────────────────────────────────────────────────────────────────────────────

WARNING: 1 target(s) are behind main by less than the 600m grace window (deploy in flight, not a failure — re-run after it lands):
  • KhataGO: answers 404; app/api/version/route.ts reached Shailesh93602/KhataGO main 489m ago (ea57f82) — inside the 600m grace window, deploy in flight

All 4 verifiable sites serve main (1 deploying).
exit=0
```

**`FRESHNESS_GRACE_MINUTES=30m`:** `FRESHNESS_GRACE_MINUTES must be a non-negative number of minutes, got "30m"` — exit 2.

## Gate (run last, on this exact tree)

`npm run lint` 0 · `npm run type-check` 0 · `npm test` **42 suites, 414 tests** passed · `npm run format:check` clean · `npm run build` ok.
